### PR TITLE
fix(database-shell): fix ignored semicolon in dot commands

### DIFF
--- a/.changeset/fix-dot-command-semicolons.md
+++ b/.changeset/fix-dot-command-semicolons.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/database-shell": patch
+---
+
+Fix dot-commands failing when arguments include a trailing semicolon (e.g. `.count users;`)

--- a/packages/database-shell/src/dot-commands.ts
+++ b/packages/database-shell/src/dot-commands.ts
@@ -49,7 +49,7 @@ export async function executeDotCommand(
   rl: readline.Interface,
   logger: ShellLogger,
 ): Promise<"quit" | "handled" | "unknown"> {
-  const parts = command.trim().split(/\s+/);
+  const parts = command.trim().replace(/;+$/, "").split(/\s+/);
   const cmd = parts[0]!.toLowerCase();
   const PRINT_MODES: PrintMode[] = [
     "default",


### PR DESCRIPTION
Fix dot-commands failing when arguments include a trailing semicolon (e.g. `.count users;`)