### PR TITLE
fix(database-studio): isolate per-table failures in studio UI

### DIFF
--- a/.changeset/improve-studio-error-handling.md
+++ b/.changeset/improve-studio-error-handling.md
@@ -1,0 +1,17 @@
+---
+"@bunny.net/database-studio": patch
+"@bunny.net/cli": patch
+---
+
+improve `db studio` error handling
+
+A single broken table used to cause cascading UI problems:
+
+- `/api/tables` would 500 if any one table's row count failed, locking
+  users out of the sidebar entirely. The endpoint now isolates per-table
+  errors and returns a `null` row count for just the broken table.
+- The client's `fetch` wrapper now surfaces the server's `error` body in
+  the thrown message instead of a bare `API error: 500`.
+- `TableView` now shows an error screen with a Retry button when a table
+  fails to load, instead of silently rendering an empty half-initialized
+  view. Refresh failures keep stale data visible with an inline banner.

--- a/packages/database-studio/client/src/App.tsx
+++ b/packages/database-studio/client/src/App.tsx
@@ -159,10 +159,16 @@ export function App() {
                         key={table.name}
                         onClick={() => { openTable(table.name); setSearch(""); }}
                         className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+                        title={table.error ?? undefined}
                       >
                         <span className="font-mono text-xs">{table.name}</span>
-                        <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
-                          {table.rowCount.toLocaleString()}
+                        <span
+                          className={cn(
+                            "font-mono text-[10px] tabular-nums",
+                            table.error ? "text-destructive" : "text-muted-foreground",
+                          )}
+                        >
+                          {table.rowCount == null ? "—" : table.rowCount.toLocaleString()}
                         </span>
                       </button>
                     ))}
@@ -188,14 +194,22 @@ export function App() {
                   <button
                     key={table.name}
                     onClick={() => openTable(table.name)}
+                    title={table.error ?? undefined}
                     className={cn(
                       "flex w-full items-center justify-between px-3 py-2 text-left transition-colors hover:bg-accent",
                       i > 0 && "border-t",
                     )}
                   >
                     <span className="font-mono text-sm">{table.name}</span>
-                    <span className="font-mono text-xs tabular-nums text-muted-foreground">
-                      {table.rowCount.toLocaleString()} rows
+                    <span
+                      className={cn(
+                        "font-mono text-xs tabular-nums",
+                        table.error ? "text-destructive" : "text-muted-foreground",
+                      )}
+                    >
+                      {table.error
+                        ? "error"
+                        : `${(table.rowCount ?? 0).toLocaleString()} rows`}
                     </span>
                   </button>
                 ))}

--- a/packages/database-studio/client/src/api.ts
+++ b/packages/database-studio/client/src/api.ts
@@ -1,6 +1,9 @@
 export interface TableSummary {
   name: string;
-  rowCount: number;
+  /** `null` when the server failed to count rows for this table. */
+  rowCount: number | null;
+  /** Server-reported error when the row count failed. */
+  error?: string;
 }
 
 export interface ColumnSchema {
@@ -35,7 +38,17 @@ const BASE = "";
 
 async function fetchJson<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`);
-  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  if (!res.ok) {
+    // Prefer the server's error message (`{ error: "..." }`) over the bare status.
+    let message = `API error: ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body && typeof body.error === "string") message = body.error;
+    } catch {
+      // Body wasn't JSON — fall back to the status-based message.
+    }
+    throw new Error(message);
+  }
   return res.json();
 }
 

--- a/packages/database-studio/client/src/components/TableView.tsx
+++ b/packages/database-studio/client/src/components/TableView.tsx
@@ -27,6 +27,7 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
   const [schema, setSchema] = useState<TableSchema | null>(null);
   const [data, setData] = useState<RowsResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<"data" | "schema">("data");
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [columnsOpen, setColumnsOpen] = useState(false);
@@ -78,25 +79,37 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
     setColumnVisibility({});
     setColumnsOpen(false);
     setLoading(true);
+    setError(null);
+    setSchema(null);
+    setData(null);
     Promise.all([fetchTableSchema(tableName), fetchTableRows(tableName, 1, limit, [], sort, filterMode)])
       .then(([s, d]) => {
         setSchema(s);
         setData(d);
       })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoading(false));
   }, [tableName]);
 
   useEffect(() => {
     setLoading(true);
     fetchTableRows(tableName, page, limit, appliedFilters, sort, filterMode)
-      .then(setData)
+      .then((d) => {
+        setData(d);
+        setError(null);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoading(false));
   }, [page, limit, tableName, filtersParam, filterModeParam, sortParam, orderParam]);
 
   function refresh() {
     setLoading(true);
     fetchTableRows(tableName, page, limit, appliedFilters, sort, filterMode)
-      .then(setData)
+      .then((d) => {
+        setData(d);
+        setError(null);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoading(false));
   }
 
@@ -140,6 +153,20 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+        <p className="text-sm font-medium text-destructive">
+          Failed to load "{tableName}"
+        </p>
+        <p className="max-w-lg font-mono text-xs text-muted-foreground">{error}</p>
+        <Button size="sm" variant="outline" className="mt-2" onClick={refresh}>
+          Retry
+        </Button>
       </div>
     );
   }
@@ -272,6 +299,12 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
           )}
         </div>
       </div>
+
+      {error && data && (
+        <div className="shrink-0 border-b bg-destructive/10 px-4 py-1.5 text-xs text-destructive">
+          Failed to refresh: <span className="font-mono">{error}</span>
+        </div>
+      )}
 
       {filtersOpen && tab === "data" && schema && (
         <FilterBar

--- a/packages/database-studio/src/server.ts
+++ b/packages/database-studio/src/server.ts
@@ -102,11 +102,21 @@ function createApiHandler(client: Client) {
       const tables = [];
       for (const row of result.rows) {
         const name = row.name as string;
-        const countResult = await client.execute(`SELECT COUNT(*) as count FROM ${quoteIdentifier(name)}`);
-        tables.push({
-          name,
-          rowCount: Number(countResult.rows[0]?.count ?? 0),
-        });
+        try {
+          const countResult = await client.execute(`SELECT COUNT(*) as count FROM ${quoteIdentifier(name)}`);
+          tables.push({
+            name,
+            rowCount: Number(countResult.rows[0]?.count ?? 0),
+          });
+        } catch (err: any) {
+          // A single broken table (e.g. corrupt index, missing attached db)
+          // shouldn't prevent the sidebar from listing the rest.
+          tables.push({
+            name,
+            rowCount: null,
+            error: err?.message ?? String(err),
+          });
+        }
       }
       return json(tables);
     }


### PR DESCRIPTION
A single 500 from one broken table would leave the UI in a half-rendered state. Three improvements:

- Server: wrap each table's COUNT(*) in try/catch so /api/tables always returns the full list; broken tables get rowCount: null + error.
- Client fetchJson: surface the server's error body in the thrown Error message instead of the bare status code.
- TableView: add an error state with a Retry button for initial load failures, and an inline banner for refresh failures so stale data stays visible.

https://claude.ai/code/session_01PCZUC1uK9DX56Fm6DnXjsx