### PR TITLE
ci(skills): add skillscheck workflow and fix the SKILL.md triggers

### DIFF
--- a/.github/workflows/skillscheck.yml
+++ b/.github/workflows/skillscheck.yml
@@ -1,0 +1,17 @@
+name: Skills Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  skillscheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - run: uvx skillscheck --strict skills

--- a/skills/bunny-cli/SKILL.md
+++ b/skills/bunny-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bunny-cli
-description: Manage bunny.net resources from the command line — databases, authentication, and raw API requests
+description: Manage bunny.net resources from the command line — databases, authentication, and raw API requests. Use when working with bunny.net (pullzones, databases, storage, magic containers), invoking the `bunny` CLI, or making authenticated API calls to api.bunny.net.
 ---
 
 # Bunny CLI Skill


### PR DESCRIPTION
Lint the skills.

They used to pass flawlessly, except for the triggers, which didn’t specify when the agent should use them.

Make this small change to help agents use the skills automatically.