### PR TITLE
Cli scripts init git argv injection

### DIFF
--- a/.changeset/silly-worlds-think.md
+++ b/.changeset/silly-worlds-think.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": patch
+---
+
+fix(scripts): pass `--` separator to `git clone` in `bunny scripts init` so the template repo URL is always treated as a positional argument, hardening against `git` argv injection.

--- a/packages/cli/src/commands/scripts/init.ts
+++ b/packages/cli/src/commands/scripts/init.ts
@@ -252,7 +252,7 @@ export const scriptsInitCommand = defineCommand<InitArgs>({
     spin.start();
 
     const clone = Bun.spawn(
-      ["git", "clone", "--depth", "1", selected.repo, dirPath],
+      ["git", "clone", "--depth", "1", "--", selected.repo, dirPath],
       { stdout: "ignore", stderr: "pipe" },
     );
     const cloneExit = await clone.exited;


### PR DESCRIPTION
Insert a `--` end-of-options separator before the template repo URL so git treats it as a positional argument, hardening `bunny scripts init --template-repo <value>` against argv injection (e.g. `--upload-pack=...` or `--config=...`) if the flag value is ever sourced from a less-trusted channel.