### PR TITLE
fix(database-studio): validate URL filters/sort and encode lookup column

### DIFF
--- a/.changeset/chubby-hornets-tease.md
+++ b/.changeset/chubby-hornets-tease.md
@@ -1,0 +1,8 @@
+---
+"@bunny.net/database-studio": patch
+"@bunny.net/database-rest": patch
+"@bunny.net/cli": patch
+"@bunny.net/database-shell": patch
+---
+
+Harden URL handling in the embedded database studio with thanks to @jedisct1

--- a/.changeset/stale-cats-chew.md
+++ b/.changeset/stale-cats-chew.md
@@ -2,4 +2,4 @@
 "@bunny.net/database-studio": patch
 ---
 
-validate URL filters/sort and encode lookup column
+validate URL filters/sort and encode lookup column with thanks to @jedisct1

--- a/.changeset/stale-cats-chew.md
+++ b/.changeset/stale-cats-chew.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/database-studio": patch
+---
+
+validate URL filters/sort and encode lookup column

--- a/packages/database-rest/README.md
+++ b/packages/database-rest/README.md
@@ -10,10 +10,15 @@ bun add @bunny.net/database-rest
 
 ## Quick start
 
+> ⚠️ `createRestHandler` does not authenticate requests. It is a CRUD
+> handler factory, not a server. **Always wrap it in an auth check before
+> exposing it to a network.** This package ships `requireAuth()` for the
+> common shared-token case; bring your own for anything more involved.
+
 ```ts
 import { createClient } from "@libsql/client";
 import { createLibSQLExecutor, introspect } from "@bunny.net/database-adapter-libsql";
-import { createRestHandler } from "@bunny.net/database-rest";
+import { createRestHandler, requireAuth } from "@bunny.net/database-rest";
 
 const client = createClient({ url: ":memory:" });
 
@@ -26,8 +31,15 @@ const schema = await introspect({ client });
 const executor = createLibSQLExecutor({ client });
 const handler = createRestHandler(executor, schema);
 
-Bun.serve({ port: 8080, fetch: handler });
+const token = process.env.API_TOKEN ?? crypto.randomUUID();
+const guarded = requireAuth(handler, { token });
+
+Bun.serve({ port: 8080, hostname: "127.0.0.1", fetch: guarded });
 ```
+
+Requests must then carry `Authorization: Bearer <token>`. See
+[`requireAuth()`](#requireauthhandler-options) for the full signature
+(cookies, public routes).
 
 ## Architecture
 
@@ -81,6 +93,53 @@ Bun.serve({ port: 8080, fetch: handler });
 | `openapi.title`   | `string`         | `"Database REST API"` | Title in the OpenAPI spec               |
 | `openapi.version` | `string`         | `schema.version`      | Version in the OpenAPI spec             |
 | `openapi.description` | `string`     | auto-generated        | Description in the OpenAPI spec         |
+
+### `requireAuth(handler, options): (req: Request) => Promise<Response>`
+
+Wraps any request handler with a shared-token check. Validates
+`Authorization: Bearer <token>` using a timing-safe comparison and
+optionally accepts the token via a named cookie. Returns `401` with
+`WWW-Authenticate: Bearer realm="database-rest"` on failure.
+
+```ts
+const guarded = requireAuth(handler, {
+  token: process.env.API_TOKEN!,
+  cookieName: "session",            // optional: also accept token in cookie
+  isPublic: (p) => p === "/auth",   // optional: pathnames to skip auth on
+});
+```
+
+#### Options
+
+| Option       | Type                              | Default | Description                                          |
+| ------------ | --------------------------------- | ------- | ---------------------------------------------------- |
+| `token`      | `string`                          | (required) | Shared secret the request must present.           |
+| `cookieName` | `string`                          | none    | If set, also accept the token from this cookie.      |
+| `isPublic`   | `(pathname: string) => boolean`   | none    | Pathnames for which auth is skipped (e.g. handshake).|
+
+#### Bringing your own auth
+
+`requireAuth` covers the shared-token case. For richer auth (Clerk,
+Auth0, JWT verification, per-row scopes), wrap `createRestHandler`'s
+result yourself; it returns a standard Web `Request → Response` handler,
+so any check that fits in a `fetch` wrapper works:
+
+```ts
+const handler = createRestHandler(executor, schema);
+
+Bun.serve({
+  fetch: async (req) => {
+    const session = await myAuthProvider.authenticate(req);
+    if (!session) return new Response("Unauthorized", { status: 401 });
+    return handler(req);
+  },
+});
+```
+
+The `requireAuth` API is intentionally shaped to grow a verifier-based
+variant (`{ verify: (req) => session | null }`) later without breaking
+existing `{ token }` callers. When there's demand, it lands as an
+additive widening.
 
 ## Endpoints
 
@@ -280,7 +339,7 @@ bun test
 
 A throwaway playground is available under `examples/` for hacking on the
 handler with curl. It binds to `127.0.0.1` and serves an in-memory SQLite
-seeded with toy data — no auth, not for production:
+seeded with toy data (no auth, not for production):
 
 ```bash
 bun run example

--- a/packages/database-rest/README.md
+++ b/packages/database-rest/README.md
@@ -272,14 +272,17 @@ const { data } = await client.GET("/users", {
 
 ## Development
 
-Run a local dev server with seed data:
+Run the tests:
 
 ```bash
-bun packages/database-rest/dev.ts
+bun test
 ```
 
-Or on a custom port:
+A throwaway playground is available under `examples/` for hacking on the
+handler with curl. It binds to `127.0.0.1` and serves an in-memory SQLite
+seeded with toy data — no auth, not for production:
 
 ```bash
-PORT=3000 bun packages/database-rest/dev.ts
+bun run example
+# or: PORT=3000 bun run example
 ```

--- a/packages/database-rest/examples/playground.ts
+++ b/packages/database-rest/examples/playground.ts
@@ -1,9 +1,14 @@
+// Loopback-only playground for hacking on @bunny.net/database-rest.
+// In-memory SQLite, seeded with toy data, reset on every start. No auth —
+// the server binds to 127.0.0.1 and the database is throwaway. Not intended
+// for production or for exposing to anything beyond localhost.
+
 import {
   createLibSQLExecutor,
   introspect,
 } from "@bunny.net/database-adapter-libsql";
 import { createClient } from "@libsql/client";
-import { createRestHandler } from "./src/index.ts";
+import { createRestHandler } from "../src/index.ts";
 
 const client = createClient({ url: ":memory:" });
 
@@ -37,12 +42,12 @@ const executor = createLibSQLExecutor({ client });
 const handler = createRestHandler(executor, schema);
 
 const port = Number(process.env.PORT) || 8080;
-const server = Bun.serve({ port, fetch: handler });
+const server = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });
 
-console.log(`Listening on http://localhost:${server.port}`);
+console.log(`Listening on http://127.0.0.1:${server.port}`);
 console.log();
 console.log("Try:");
-const base = `http://localhost:${server.port}`;
+const base = `http://127.0.0.1:${server.port}`;
 console.log(`  curl ${base}/                              # OpenAPI spec`);
 console.log(`  curl ${base}/users                         # List users`);
 console.log(`  curl ${base}/users?select=id,name          # Select columns`);

--- a/packages/database-rest/examples/playground.ts
+++ b/packages/database-rest/examples/playground.ts
@@ -1,5 +1,5 @@
 // Loopback-only playground for hacking on @bunny.net/database-rest.
-// In-memory SQLite, seeded with toy data, reset on every start. No auth —
+// In-memory SQLite, seeded with toy data, reset on every start. No auth:
 // the server binds to 127.0.0.1 and the database is throwaway. Not intended
 // for production or for exposing to anything beyond localhost.
 

--- a/packages/database-rest/package.json
+++ b/packages/database-rest/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "dev": "bun run dev.ts",
+    "example": "bun run examples/playground.ts",
     "test": "bun test",
     "typecheck": "bun run tsc --noEmit"
   },

--- a/packages/database-rest/src/auth.test.ts
+++ b/packages/database-rest/src/auth.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { type RequireAuthOptions, requireAuth } from "./auth.ts";
+
+const TOKEN = "secret";
+
+const run = ({
+  opts,
+  headers,
+  path = "/",
+}: {
+  opts: RequireAuthOptions;
+  headers?: Record<string, string>;
+  path?: string;
+}) =>
+  requireAuth(
+    () => new Response("ok"),
+    opts,
+  )(new Request(`http://localhost${path}`, { headers }));
+
+describe("requireAuth", () => {
+  test("401 with WWW-Authenticate when no credentials", async () => {
+    const res = await run({ opts: { token: TOKEN } });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toBe(
+      'Bearer realm="database-rest"',
+    );
+  });
+
+  test.each([
+    ["valid bearer", "Bearer secret", 200],
+    ["case-insensitive scheme", "bearer secret", 200],
+    ["wrong bearer token", "Bearer nope", 401],
+    ["non-bearer scheme", "Basic secret", 401],
+  ])("bearer: %s", async (_, authorization, expected) => {
+    const res = await run({
+      opts: { token: TOKEN },
+      headers: { authorization },
+    });
+    expect(res.status).toBe(expected);
+  });
+
+  test.each([
+    [
+      "matching cookie",
+      { cookieName: "session" },
+      "session=secret; other=foo",
+      200,
+    ],
+    ["wrong cookie", { cookieName: "session" }, "session=nope", 401],
+    ["cookie ignored when cookieName unset", {}, "session=secret", 401],
+  ])("cookie: %s", async (_, extra, cookie, expected) => {
+    const res = await run({
+      opts: { token: TOKEN, ...extra },
+      headers: { cookie },
+    });
+    expect(res.status).toBe(expected);
+  });
+
+  test.each([
+    ["public path skips auth", "/auth", 200],
+    ["non-public path still gated", "/data", 401],
+  ])("isPublic: %s", async (_, path, expected) => {
+    const res = await run({
+      opts: { token: TOKEN, isPublic: (p) => p === "/auth" },
+      path,
+    });
+    expect(res.status).toBe(expected);
+  });
+});

--- a/packages/database-rest/src/auth.ts
+++ b/packages/database-rest/src/auth.ts
@@ -1,0 +1,133 @@
+// Shared-token auth wrapper. The shape (options bag, optional callbacks,
+// exported option type) is intentionally designed so future variants can
+// be added without breaking existing callers:
+//   - A verifier-based variant (Clerk, Auth0, JWT, etc.) lands by widening
+//     RequireAuthOptions to a union; today's TokenAuthOptions stays valid.
+//   - Session context can flow into the handler via an optional second arg.
+//   - isPublic can grow optional arguments (e.g. the full Request) without
+//     breaking pathname-only callers.
+//   - Response customisation lands as new optional fields (e.g. onUnauthorized).
+// Keep these surfaces open when editing.
+
+import { timingSafeEqual } from "node:crypto";
+
+const safeEqual = (a: string, b: string): boolean => {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+};
+
+const extractCookie = (req: Request, name: string): string | null => {
+  const header = req.headers.get("cookie");
+  if (!header) return null;
+  for (const pair of header.split(";")) {
+    const trimmed = pair.trim();
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    if (trimmed.slice(0, eq) === name) return trimmed.slice(eq + 1);
+  }
+  return null;
+};
+
+const unauthorized = (): Response =>
+  new Response(JSON.stringify({ message: "Unauthorized" }), {
+    status: 401,
+    headers: {
+      "Content-Type": "application/json",
+      "WWW-Authenticate": 'Bearer realm="database-rest"',
+    },
+  });
+
+export interface RequireAuthOptions {
+  /** Shared secret the request must present. */
+  token: string;
+  /** If set, also accept the token from this cookie. */
+  cookieName?: string;
+  /** Optional predicate: pathnames for which auth is skipped. */
+  isPublic?: (pathname: string) => boolean;
+}
+
+/**
+ * Wrap a request handler with a shared-token check.
+ *
+ * Accepts the token via `Authorization: Bearer <token>` and, optionally,
+ * via a named cookie. Comparison is timing-safe. Returns 401 with
+ * `WWW-Authenticate: Bearer realm="database-rest"` on failure.
+ *
+ * @example Basic bearer
+ * ```ts
+ * import { createRestHandler, requireAuth } from "@bunny.net/database-rest";
+ *
+ * const handler = createRestHandler(executor, schema);
+ * const guarded = requireAuth(handler, { token: process.env.API_TOKEN! });
+ *
+ * Bun.serve({ port: 8080, hostname: "127.0.0.1", fetch: guarded });
+ * ```
+ *
+ * @example Cookie + bearer with a public handshake route
+ * ```ts
+ * const guarded = requireAuth(handler, {
+ *   token: sessionToken,
+ *   cookieName: "session",
+ *   isPublic: (p) => p === "/auth",
+ * });
+ * ```
+ *
+ * @remarks
+ * `requireAuth` covers the shared-token case. For richer auth (Clerk,
+ * Auth0, JWT verification, per-row scopes), wrap `createRestHandler`'s
+ * result yourself; it returns a standard Web `Request` → `Response`
+ * handler, so any check that fits in a `fetch` wrapper works:
+ *
+ * ```ts
+ * Bun.serve({
+ *   fetch: async (req) => {
+ *     const session = await myAuthProvider.authenticate(req);
+ *     if (!session) return new Response("Unauthorized", { status: 401 });
+ *     return handler(req);
+ *   },
+ * });
+ * ```
+ *
+ * The API is shaped so a verifier-based variant
+ * (`{ verify: (req) => session | null }`) can land later as an additive
+ * widening of {@link RequireAuthOptions}, without breaking existing
+ * `{ token }` callers.
+ */
+export const requireAuth = (
+  handler: (req: Request) => Response | Promise<Response>,
+  options: RequireAuthOptions,
+): ((req: Request) => Promise<Response>) => {
+  return async (req: Request): Promise<Response> => {
+    if (options.isPublic) {
+      const { pathname } = new URL(req.url);
+      if (options.isPublic(pathname)) return handler(req);
+    }
+
+    const authHeader = req.headers.get("authorization");
+    if (authHeader) {
+      const spaceIndex = authHeader.indexOf(" ");
+      if (spaceIndex > 0) {
+        const scheme = authHeader.slice(0, spaceIndex);
+        const presented = authHeader.slice(spaceIndex + 1).trim();
+        if (
+          scheme.toLowerCase() === "bearer" &&
+          presented &&
+          safeEqual(presented, options.token)
+        ) {
+          return handler(req);
+        }
+      }
+    }
+
+    if (options.cookieName) {
+      const cookie = extractCookie(req, options.cookieName);
+      if (cookie && safeEqual(cookie, options.token)) {
+        return handler(req);
+      }
+    }
+
+    return unauthorized();
+  };
+};

--- a/packages/database-rest/src/index.ts
+++ b/packages/database-rest/src/index.ts
@@ -1,3 +1,5 @@
+export type { RequireAuthOptions } from "./auth.ts";
+export { requireAuth } from "./auth.ts";
 export type { DatabaseExecutor, ExecuteResult } from "./executor.ts";
 export type { RestHandlerOptions } from "./handler.ts";
 export { createRestHandler } from "./handler.ts";

--- a/packages/database-studio/client/src/api.ts
+++ b/packages/database-studio/client/src/api.ts
@@ -166,6 +166,19 @@ export interface FilterCondition {
 
 export type FilterMode = "and" | "or";
 
+export const FILTER_OPERATORS = new Set([
+  "=",
+  "!=",
+  ">",
+  "<",
+  ">=",
+  "<=",
+  "LIKE",
+  "NOT LIKE",
+  "IS NULL",
+  "IS NOT NULL",
+]);
+
 // Map studio UI operators to PostgREST query param format
 const mapFilter = (f: FilterCondition): [string, string] => {
   switch (f.operator) {

--- a/packages/database-studio/client/src/api.ts
+++ b/packages/database-studio/client/src/api.ts
@@ -140,7 +140,7 @@ export const fetchRowLookup = async (
   value: string,
 ): Promise<RowLookupResponse> => {
   const res = await fetch(
-    `${BASE}/api/${encodeURIComponent(table)}?${column}=eq.${encodeURIComponent(value)}&limit=1`,
+    `${BASE}/api/${encodeURIComponent(table)}?${encodeURIComponent(column)}=eq.${encodeURIComponent(value)}&limit=1`,
   );
   if (!res.ok) throw new Error(`Lookup failed: ${res.status}`);
   const body = await res.json();

--- a/packages/database-studio/client/src/components/FilterBar.tsx
+++ b/packages/database-studio/client/src/components/FilterBar.tsx
@@ -25,8 +25,6 @@ const OPERATORS = [
   { value: "IS NOT NULL", label: "IS NOT NULL" },
 ];
 
-export const FILTER_OPERATORS = new Set(OPERATORS.map((o) => o.value));
-
 export const NULLARY_OPERATORS = new Set(["IS NULL", "IS NOT NULL"]);
 
 export interface FilterBarProps {

--- a/packages/database-studio/client/src/components/FilterBar.tsx
+++ b/packages/database-studio/client/src/components/FilterBar.tsx
@@ -25,6 +25,8 @@ const OPERATORS = [
   { value: "IS NOT NULL", label: "IS NOT NULL" },
 ];
 
+export const FILTER_OPERATORS = new Set(OPERATORS.map((o) => o.value));
+
 export const NULLARY_OPERATORS = new Set(["IS NULL", "IS NOT NULL"]);
 
 export interface FilterBarProps {

--- a/packages/database-studio/client/src/components/TableView.tsx
+++ b/packages/database-studio/client/src/components/TableView.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
+  FILTER_OPERATORS,
   type FilterCondition,
   type FilterMode,
   fetchTableRows,
@@ -17,11 +18,7 @@ import {
 } from "@/api.ts";
 import { ColumnToggleMenu } from "@/components/ColumnToggleMenu";
 import { DataTab } from "@/components/DataTab";
-import {
-  FILTER_OPERATORS,
-  FilterBar,
-  NULLARY_OPERATORS,
-} from "@/components/FilterBar";
+import { FilterBar, NULLARY_OPERATORS } from "@/components/FilterBar";
 import { SchemaTab } from "@/components/SchemaTab";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -108,6 +105,7 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
   }, [appliedFilters.length]);
 
   useEffect(() => {
+    let cancelled = false;
     setTab("data");
     setColumnVisibility({});
     setColumnsOpen(false);
@@ -116,23 +114,41 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
     setSchema(null);
     setData(null);
     fetchTableSchema(tableName)
-      .then((s) => setSchema(s))
+      .then((s) => {
+        if (cancelled) return;
+        setSchema(s);
+      })
       .catch((e) => {
+        if (cancelled) return;
         setError(e instanceof Error ? e.message : String(e));
         setLoading(false);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [tableName]);
 
   useEffect(() => {
     if (!schema) return;
+    let cancelled = false;
     setLoading(true);
     fetchTableRows(tableName, page, limit, appliedFilters, sort, filterMode)
       .then((d) => {
+        if (cancelled) return;
         setData(d);
         setError(null);
       })
-      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
-      .finally(() => setLoading(false));
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [page, limit, tableName, filterMode, sort, appliedFilters, schema]);
 
   function refresh() {

--- a/packages/database-studio/client/src/components/TableView.tsx
+++ b/packages/database-studio/client/src/components/TableView.tsx
@@ -17,7 +17,11 @@ import {
 } from "@/api.ts";
 import { ColumnToggleMenu } from "@/components/ColumnToggleMenu";
 import { DataTab } from "@/components/DataTab";
-import { FilterBar, NULLARY_OPERATORS } from "@/components/FilterBar";
+import {
+  FILTER_OPERATORS,
+  FilterBar,
+  NULLARY_OPERATORS,
+} from "@/components/FilterBar";
 import { SchemaTab } from "@/components/SchemaTab";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -54,28 +58,48 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
   const page = Math.max(1, Number(pageParam) || 1);
   const limit = Math.min(100, Math.max(1, Number(limitParam) || 50));
 
-  const sortState: SortingState = useMemo(() => {
-    if (!sortParam) return [];
-    return [{ id: sortParam, desc: orderParam === "desc" }];
-  }, [sortParam, orderParam]);
+  const columnNames = useMemo(() => {
+    if (!schema) return null;
+    return new Set(schema.columns.map((c) => c.name));
+  }, [schema]);
 
   const sort = useMemo(() => {
-    if (!sortParam) return undefined;
+    if (!sortParam || !columnNames?.has(sortParam)) {
+      return undefined;
+    }
     return {
       column: sortParam,
       order: (orderParam === "desc" ? "desc" : "asc") as "asc" | "desc",
     };
-  }, [sortParam, orderParam]);
+  }, [sortParam, orderParam, columnNames]);
+
+  const sortState: SortingState = useMemo(() => {
+    if (!sort) return [];
+    return [{ id: sort.column, desc: sort.order === "desc" }];
+  }, [sort]);
 
   const appliedFilters: FilterCondition[] = useMemo(() => {
-    if (!filtersParam) return [];
+    if (!filtersParam || !columnNames) return [];
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(filtersParam);
-      return Array.isArray(parsed) ? parsed : [];
+      parsed = JSON.parse(filtersParam);
     } catch {
       return [];
     }
-  }, [filtersParam]);
+    if (!Array.isArray(parsed)) return [];
+    const validated: FilterCondition[] = [];
+    for (const entry of parsed) {
+      if (!entry || typeof entry !== "object") continue;
+      const { column, operator, value } = entry as Record<string, unknown>;
+      if (typeof column !== "string" || !columnNames.has(column)) continue;
+      if (typeof operator !== "string" || !FILTER_OPERATORS.has(operator)) {
+        continue;
+      }
+      if (typeof value !== "string") continue;
+      validated.push({ column, operator, value });
+    }
+    return validated;
+  }, [filtersParam, columnNames]);
 
   // Sync filter row count from URL on table change
   useEffect(() => {
@@ -91,19 +115,16 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
     setError(null);
     setSchema(null);
     setData(null);
-    Promise.all([
-      fetchTableSchema(tableName),
-      fetchTableRows(tableName, 1, limit, [], sort, filterMode),
-    ])
-      .then(([s, d]) => {
-        setSchema(s);
-        setData(d);
-      })
-      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
-      .finally(() => setLoading(false));
-  }, [tableName, limit, filterMode, sort]);
+    fetchTableSchema(tableName)
+      .then((s) => setSchema(s))
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      });
+  }, [tableName]);
 
   useEffect(() => {
+    if (!schema) return;
     setLoading(true);
     fetchTableRows(tableName, page, limit, appliedFilters, sort, filterMode)
       .then((d) => {
@@ -112,7 +133,7 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
       })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoading(false));
-  }, [page, limit, tableName, filterMode, sort, appliedFilters]);
+  }, [page, limit, tableName, filterMode, sort, appliedFilters, schema]);
 
   function refresh() {
     setLoading(true);

--- a/packages/database-studio/src/server.ts
+++ b/packages/database-studio/src/server.ts
@@ -4,7 +4,7 @@ import {
   createLibSQLExecutor,
   introspect,
 } from "@bunny.net/database-adapter-libsql";
-import { createRestHandler } from "@bunny.net/database-rest";
+import { createRestHandler, requireAuth } from "@bunny.net/database-rest";
 import type { Client } from "@libsql/client";
 import { assets } from "./client-manifest.ts";
 
@@ -41,24 +41,6 @@ const safeEqual = (a: string, b: string): boolean => {
   return timingSafeEqual(ab, bb);
 };
 
-const extractCookie = (req: Request, name: string): string | null => {
-  const header = req.headers.get("cookie");
-  if (!header) return null;
-  for (const pair of header.split(";")) {
-    const trimmed = pair.trim();
-    const eq = trimmed.indexOf("=");
-    if (eq < 0) continue;
-    if (trimmed.slice(0, eq) === name) return trimmed.slice(eq + 1);
-  }
-  return null;
-};
-
-const unauthorized = (): Response =>
-  new Response(JSON.stringify({ message: "Unauthorized" }), {
-    status: 401,
-    headers: { "Content-Type": "application/json" },
-  });
-
 const handleAuth = async (
   req: Request,
   sessionToken: string,
@@ -77,7 +59,10 @@ const handleAuth = async (
   }
   const provided = (body as { token?: unknown })?.token;
   if (typeof provided !== "string" || !safeEqual(provided, sessionToken)) {
-    return unauthorized();
+    return new Response(JSON.stringify({ message: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   return new Response(null, {
     status: 204,
@@ -101,11 +86,14 @@ export async function startStudio(options: StudioOptions): Promise<void> {
 
   const schema = await introspect({ client });
   const executor = createLibSQLExecutor({ client });
-  const handleRest = createRestHandler(executor, schema, { basePath: "/api" });
   // Random per-startup token. The auto-opened browser URL carries it once as
   // ?token=…; the client posts it to /api/auth which then sets an HttpOnly
   // cookie that gates every subsequent /api/* request.
   const sessionToken = randomBytes(32).toString("hex");
+  const handleRest = requireAuth(
+    createRestHandler(executor, schema, { basePath: "/api" }),
+    { token: sessionToken, cookieName: AUTH_COOKIE },
+  );
 
   let server: ReturnType<typeof Bun.serve>;
   try {
@@ -125,14 +113,10 @@ export async function startStudio(options: StudioOptions): Promise<void> {
 
         // API routes - delegate to REST handler
         if (pathname.startsWith("/api")) {
-          // /api/auth is the handshake endpoint — public but only succeeds
+          // /api/auth is the handshake endpoint: public but only succeeds
           // with the correct session token.
           if (pathname === "/api/auth") {
             return await handleAuth(req, sessionToken);
-          }
-          const cookie = extractCookie(req, AUTH_COOKIE);
-          if (!cookie || !safeEqual(cookie, sessionToken)) {
-            return unauthorized();
           }
           try {
             return await handleRest(req);


### PR DESCRIPTION
Addresses Swival security audit findings 015, 016, 008, 031, 032;

- Encode the column parameter in fetchRowLookup so it cannot inject extra query params via `&/=/#` delimiters
- Validate URL filter entries against the table schema and an operator allowlist before sending them to the row fethc
- Validate the URL sort column against the table schema before sending it to the row fetch

Big thanks to @jedisct1 ❤️ 