### PR TITLE
fix(cli/scripts-init): confirm before installing deps for custom templates

### DIFF
--- a/.changeset/hungry-moments-cough.md
+++ b/.changeset/hungry-moments-cough.md
@@ -3,3 +3,5 @@
 ---
 
 confirm before installing deps for custom templates
+
+Thanks to @jedisct1 for the report.

--- a/.changeset/hungry-moments-cough.md
+++ b/.changeset/hungry-moments-cough.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": patch
+---
+
+confirm before installing deps for custom templates

--- a/.changeset/swift-foxes-jump.md
+++ b/.changeset/swift-foxes-jump.md
@@ -2,4 +2,6 @@
 "@bunny.net/cli": patch
 ---
 
-Require confirmation before installing dependencies when `bunny scripts init` uses a custom template repo (`--template-repo` / `--repo`). Previously, non-interactive runs auto-ran `bun install`, which would silently execute a malicious template's lifecycle scripts (preinstall, postinstall). Built-in template behavior is unchanged. Thanks to @Swival for the report.
+Require confirmation before installing dependencies when `bunny scripts init` uses a custom template repo (`--template-repo` / `--repo`). Previously, non-interactive runs auto-ran `bun install`, which would silently execute a malicious template's lifecycle scripts (preinstall, postinstall). Built-in template behavior is unchanged.
+
+Thanks to @jedisct1 for the report.

--- a/.changeset/swift-foxes-jump.md
+++ b/.changeset/swift-foxes-jump.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": patch
+---
+
+Require confirmation before installing dependencies when `bunny scripts init` uses a custom template repo (`--template-repo` / `--repo`). Previously, non-interactive runs auto-ran `bun install`, which would silently execute a malicious template's lifecycle scripts (preinstall, postinstall). Built-in template behavior is unchanged. Thanks to @Swival for the report.

--- a/.changeset/swift-foxes-jump.md
+++ b/.changeset/swift-foxes-jump.md
@@ -1,7 +1,0 @@
----
-"@bunny.net/cli": patch
----
-
-Require confirmation before installing dependencies when `bunny scripts init` uses a custom template repo (`--template-repo` / `--repo`). Previously, non-interactive runs auto-ran `bun install`, which would silently execute a malicious template's lifecycle scripts (preinstall, postinstall). Built-in template behavior is unchanged.
-
-Thanks to @jedisct1 for the report.

--- a/packages/cli/src/commands/scripts/init.ts
+++ b/packages/cli/src/commands/scripts/init.ts
@@ -298,9 +298,13 @@ export const scriptsInitCommand = defineCommand<InitArgs>({
       existsSync(`${dirPath}/package.json`) &&
       args[ARG_SKIP_INSTALL] !== true
     ) {
-      const shouldInstall = interactive
-        ? await confirm("Install dependencies?")
-        : true;
+      // Always confirm before installing for custom template repos —
+      // a malicious template's lifecycle scripts (preinstall, postinstall)
+      // would otherwise run silently in non-interactive mode.
+      const shouldInstall =
+        interactive || args[ARG_TEMPLATE_REPO]
+          ? await confirm("Install dependencies?")
+          : true;
       if (shouldInstall) {
         const installSpin = spinner("Installing dependencies...");
         installSpin.start();


### PR DESCRIPTION
Require confirmation before installing dependencies when `bunny scripts init`. Addresses https://github.com/Swival/security-audits/blob/main/bunnycdn-cli/001-custom-template-auto-installs-dependencies.md