### PR TITLE
fix: route logger human-readable output to stderr to avoid polluting JSON stdout

### DIFF
--- a/.changeset/slick-plums-bow.md
+++ b/.changeset/slick-plums-bow.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": minor
+---
+
+fix: route logger human-readable output to stderr to avoid polluting JSON stdout

--- a/.changeset/slick-plums-bow.md
+++ b/.changeset/slick-plums-bow.md
@@ -1,5 +1,5 @@
 ---
-"@bunny.net/cli": minor
+"@bunny.net/cli": patch
 ---
 
 fix: route logger human-readable output to stderr to avoid polluting JSON stdout

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "bun-ny-cli",

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -14,11 +14,12 @@ export interface ResolvedConfig {
 export function resolveConfig(
   profile: string,
   apiKeyOverride?: string,
+  verbose?: boolean,
 ): ResolvedConfig {
   const envApiUrl = process.env.BUNNYNET_API_URL || undefined;
 
   if (apiKeyOverride) {
-    logger.debug("API key loaded from --api-key flag", true);
+    logger.debug("API key loaded from --api-key flag", verbose ?? false);
     return {
       apiKey: apiKeyOverride,
       apiUrl: envApiUrl,
@@ -29,7 +30,7 @@ export function resolveConfig(
   const envApiKey = process.env.BUNNYNET_API_KEY;
 
   if (envApiKey) {
-    logger.debug("API key loaded from BUNNYNET_API_KEY", true);
+    logger.debug("API key loaded from BUNNYNET_API_KEY", verbose ?? false);
     return {
       apiKey: envApiKey,
       apiUrl: envApiUrl,

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -17,9 +17,10 @@ export function resolveConfig(
   verbose?: boolean,
 ): ResolvedConfig {
   const envApiUrl = process.env.BUNNYNET_API_URL || undefined;
+  const isVerbose = verbose ?? false;
 
   if (apiKeyOverride) {
-    logger.debug("API key loaded from --api-key flag", verbose ?? false);
+    logger.debug("API key loaded from --api-key flag", isVerbose);
     return {
       apiKey: apiKeyOverride,
       apiUrl: envApiUrl,
@@ -30,7 +31,7 @@ export function resolveConfig(
   const envApiKey = process.env.BUNNYNET_API_KEY;
 
   if (envApiKey) {
-    logger.debug("API key loaded from BUNNYNET_API_KEY", verbose ?? false);
+    logger.debug("API key loaded from BUNNYNET_API_KEY", isVerbose);
     return {
       apiKey: envApiKey,
       apiUrl: envApiUrl,

--- a/packages/cli/src/core/logger.ts
+++ b/packages/cli/src/core/logger.ts
@@ -2,12 +2,12 @@ import chalk from "chalk";
 
 export const logger = {
   log: (msg = "") => console.log(msg),
-  info: (msg: string) => console.log(chalk.blue("ℹ"), msg),
-  success: (msg: string) => console.log(chalk.green("✓"), msg),
-  warn: (msg: string) => console.log(chalk.yellow("⚠"), msg),
+  info: (msg: string) => console.error(chalk.blue("ℹ"), msg),
+  success: (msg: string) => console.error(chalk.green("✓"), msg),
+  warn: (msg: string) => console.error(chalk.yellow("⚠"), msg),
   error: (msg: string) => console.error(chalk.red("✖"), msg),
-  dim: (msg: string) => console.log(chalk.dim(msg)),
+  dim: (msg: string) => console.error(chalk.dim(msg)),
   debug: (msg: string, verbose: boolean) => {
-    if (verbose) console.log(chalk.gray("[debug]"), msg);
+    if (verbose) console.error(chalk.gray("[debug]"), msg);
   },
 };


### PR DESCRIPTION
_Note: Created with love for the BunnyWay using CoPilot! /David_ 

## Summary

When running with `--output json` (common in CI), human-readable log messages were written to **stdout**, corrupting the JSON output stream. For example, `[debug] API key loaded from BUNNYNET_API_KEY` would appear inline with the JSON payload, breaking any downstream JSON parser.

## Root Causes

1. **`logger.ts`**: `info`, `success`, `warn`, `dim`, and `debug` all used `console.log` (stdout). Only `error` correctly used `console.error` (stderr).

2. **`config/index.ts`**: `logger.debug` was called with a hardcoded `true` as the `verbose` flag, causing the debug messages to always print regardless of whether `--verbose` was passed.

## Changes

### `packages/cli/src/core/logger.ts`
- Changed `info`, `success`, `warn`, `dim`, and `debug` from `console.log` → `console.error`
- `logger.log` (used for actual data output like tables and JSON) remains on stdout
- `logger.error` was already on stderr — unchanged

This follows the standard Unix convention: **stdout = data, stderr = messages/logs**, so that piping and JSON parsing work correctly regardless of output format.

### `packages/cli/src/config/index.ts`
- Added optional `verbose?: boolean` parameter to `resolveConfig()` (defaults to `false` when omitted — all existing callers are unaffected)
- Replaced the hardcoded `true` in both `logger.debug` calls with `isVerbose`, so the API key source messages are only shown when `--verbose` is explicitly passed
- Extracted `const isVerbose = verbose ?? false` to a single location to avoid repetition

## Before / After

**Before** (`bunny db list --output json` with `BUNNYNET_API_KEY` set):
```
[debug] API key loaded from BUNNYNET_API_KEY
[{"id":"db_01...","name":"my-db",...}]
```

**After**:
```
stdout: [{"id":"db_01...","name":"my-db",...}]
stderr: (nothing, unless --verbose is passed)
```
