### PR TITLE
fix(database-studio): restore foreign key UI and stabilize table layout

### DIFF
--- a/.changeset/dull-carrots-win.md
+++ b/.changeset/dull-carrots-win.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/database-openapi": minor
+---
+
+add indexes

--- a/.changeset/great-ghosts-boil.md
+++ b/.changeset/great-ghosts-boil.md
@@ -1,0 +1,6 @@
+---
+"@bunny.net/database-openapi": minor
+"@bunny.net/database-studio": minor
+---
+
+Restore foreign key support in Database Studio. The OpenAPI generator now emits an `x-foreign-key` extension on column schemas, and the studio reads it to show `FK` badges in column headers and let you click a foreign key value to open the referenced row in a side sheet. Also fixes the sticky table header during vertical scroll and a small vertical shift in the Data/Schema toolbar when switching tabs.

--- a/bun.lock
+++ b/bun.lock
@@ -143,6 +143,7 @@
       "version": "0.1.2",
       "dependencies": {
         "@bunny.net/database-adapter-libsql": "workspace:*",
+        "@bunny.net/database-openapi": "workspace:*",
         "@bunny.net/database-rest": "workspace:*",
         "@libsql/client": "^0.17.0",
       },

--- a/packages/database-openapi/src/generate.ts
+++ b/packages/database-openapi/src/generate.ts
@@ -81,6 +81,7 @@ export interface SchemaObject {
   oneOf?: SchemaObject[];
   nullable?: boolean;
   example?: unknown;
+  "x-foreign-key"?: { table: string; column: string };
 }
 
 const NAME_EXAMPLES: [RegExp, unknown][] = [
@@ -199,8 +200,20 @@ const tableToSchema = (table: TableDefinition): SchemaObject => {
   const properties: Record<string, SchemaObject> = {};
   const required: string[] = [];
 
+  const fkByColumn = new Map(
+    table.foreignKeys.map((fk) => [fk.column, fk] as const),
+  );
+
   for (const column of table.columns) {
-    properties[column.name] = columnTypeToSchema(column);
+    const schema = columnTypeToSchema(column);
+    const fk = fkByColumn.get(column.name);
+    if (fk) {
+      schema["x-foreign-key"] = {
+        table: fk.referencesTable,
+        column: fk.referencesColumn,
+      };
+    }
+    properties[column.name] = schema;
     if (
       !column.nullable &&
       column.defaultValue === undefined &&

--- a/packages/database-openapi/src/generate.ts
+++ b/packages/database-openapi/src/generate.ts
@@ -82,6 +82,7 @@ export interface SchemaObject {
   nullable?: boolean;
   example?: unknown;
   "x-foreign-key"?: { table: string; column: string };
+  "x-indexes"?: Array<{ name: string; columns: string[]; unique: boolean }>;
 }
 
 const NAME_EXAMPLES: [RegExp, unknown][] = [
@@ -227,6 +228,7 @@ const tableToSchema = (table: TableDefinition): SchemaObject => {
     type: "object",
     properties,
     ...(required.length > 0 ? { required } : {}),
+    ...(table.indexes.length > 0 ? { "x-indexes": table.indexes } : {}),
   };
 };
 

--- a/packages/database-studio/client/src/api.ts
+++ b/packages/database-studio/client/src/api.ts
@@ -1,4 +1,12 @@
 // OpenAPI spec types (subset we use)
+interface OpenAPIColumnSchema {
+  type?: string;
+  format?: string;
+  nullable?: boolean;
+  example?: unknown;
+  "x-foreign-key"?: { table: string; column: string };
+}
+
 interface OpenAPISpec {
   paths: Record<string, unknown>;
   components: {
@@ -6,15 +14,7 @@ interface OpenAPISpec {
       string,
       {
         type?: string;
-        properties?: Record<
-          string,
-          {
-            type?: string;
-            format?: string;
-            nullable?: boolean;
-            example?: unknown;
-          }
-        >;
+        properties?: Record<string, OpenAPIColumnSchema>;
         required?: string[];
       }
     >;
@@ -108,11 +108,18 @@ export const fetchTableSchema = async (name: string): Promise<TableSchema> => {
     },
   );
 
-  // Foreign keys and indexes aren't in the OpenAPI spec - return empty for now
-  // The schema tab will show what's available from the spec
+  const foreignKeys: TableSchema["foreignKeys"] = [];
+  for (const [colName, colSchema] of Object.entries(tableSchema.properties)) {
+    const fk = colSchema["x-foreign-key"];
+    if (fk) {
+      foreignKeys.push({ from: colName, table: fk.table, to: fk.column });
+    }
+  }
+
+  // Indexes aren't in the OpenAPI spec - return empty for now
   return {
     columns,
-    foreignKeys: [],
+    foreignKeys,
     indexes: [],
   };
 };

--- a/packages/database-studio/client/src/api.ts
+++ b/packages/database-studio/client/src/api.ts
@@ -1,25 +1,4 @@
-// OpenAPI spec types (subset we use)
-interface OpenAPIColumnSchema {
-  type?: string;
-  format?: string;
-  nullable?: boolean;
-  example?: unknown;
-  "x-foreign-key"?: { table: string; column: string };
-}
-
-interface OpenAPITableSchema {
-  type?: string;
-  properties?: Record<string, OpenAPIColumnSchema>;
-  required?: string[];
-  "x-indexes"?: Array<{ name: string; columns: string[]; unique: boolean }>;
-}
-
-interface OpenAPISpec {
-  paths: Record<string, unknown>;
-  components: {
-    schemas: Record<string, OpenAPITableSchema>;
-  };
-}
+import type { OpenAPISpec } from "@bunny.net/database-openapi";
 
 export interface TableSummary {
   name: string;

--- a/packages/database-studio/client/src/api.ts
+++ b/packages/database-studio/client/src/api.ts
@@ -7,17 +7,17 @@ interface OpenAPIColumnSchema {
   "x-foreign-key"?: { table: string; column: string };
 }
 
+interface OpenAPITableSchema {
+  type?: string;
+  properties?: Record<string, OpenAPIColumnSchema>;
+  required?: string[];
+  "x-indexes"?: Array<{ name: string; columns: string[]; unique: boolean }>;
+}
+
 interface OpenAPISpec {
   paths: Record<string, unknown>;
   components: {
-    schemas: Record<
-      string,
-      {
-        type?: string;
-        properties?: Record<string, OpenAPIColumnSchema>;
-        required?: string[];
-      }
-    >;
+    schemas: Record<string, OpenAPITableSchema>;
   };
 }
 
@@ -116,11 +116,16 @@ export const fetchTableSchema = async (name: string): Promise<TableSchema> => {
     }
   }
 
-  // Indexes aren't in the OpenAPI spec - return empty for now
+  const indexes: TableSchema["indexes"] =
+    tableSchema["x-indexes"]?.map((idx) => ({
+      name: idx.name,
+      unique: idx.unique,
+    })) ?? [];
+
   return {
     columns,
     foreignKeys,
-    indexes: [],
+    indexes,
   };
 };
 

--- a/packages/database-studio/client/src/components/DataTab.tsx
+++ b/packages/database-studio/client/src/components/DataTab.tsx
@@ -190,7 +190,7 @@ export function DataTab({
 
   return (
     <>
-      <div className="flex-1 overflow-auto">
+      <div className="flex flex-1 min-h-0 flex-col">
         <DataTable
           columns={columns}
           data={data.rows as RowRecord[]}

--- a/packages/database-studio/client/src/components/TableView.tsx
+++ b/packages/database-studio/client/src/components/TableView.tsx
@@ -230,8 +230,8 @@ export function TableView({ tableName, onSelectTable }: TableViewProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex h-10 shrink-0 items-center gap-1 border-b px-4">
-        <div className="flex gap-1">
+      <div className="flex h-10 min-h-10 max-h-10 shrink-0 items-center gap-1 border-b px-4">
+        <div className="flex items-center gap-1">
           <Button
             variant={tab === "data" ? "secondary" : "ghost"}
             size="sm"

--- a/packages/database-studio/client/src/components/ui/data-table.tsx
+++ b/packages/database-studio/client/src/components/ui/data-table.tsx
@@ -130,7 +130,10 @@ export function DataTable<TData, TValue>({
   const colCount = columns.length + (onInspectRow ? 1 : 0);
 
   return (
-    <Table style={{ minWidth: `${colCount * 150}px` }}>
+    <Table
+      containerClassName="h-full"
+      style={{ minWidth: `${colCount * 150}px` }}
+    >
       <TableHeader className="sticky top-0 z-10 bg-card">
         {table.getHeaderGroups().map((headerGroup) => (
           <TableRow key={headerGroup.id}>

--- a/packages/database-studio/client/src/components/ui/table.tsx
+++ b/packages/database-studio/client/src/components/ui/table.tsx
@@ -1,9 +1,16 @@
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<"table"> & { containerClassName?: string }) {
   return (
-    <div data-slot="table-container" className="relative w-full overflow-auto">
+    <div
+      data-slot="table-container"
+      className={cn("relative w-full overflow-auto", containerClassName)}
+    >
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}

--- a/packages/database-studio/package.json
+++ b/packages/database-studio/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@bunny.net/database-adapter-libsql": "workspace:*",
+    "@bunny.net/database-openapi": "workspace:*",
     "@bunny.net/database-rest": "workspace:*",
     "@libsql/client": "^0.17.0"
   },


### PR DESCRIPTION
- Emit x-foreign-key extension on column schemas in the OpenAPI generator
- Make the table header sticky
- Lock the Data/Schema toolbar to a fixed height
- Import OpenAPI types now we have them