### PR TITLE
Fix/credential source debug respects verbose

### DIFF
--- a/.changeset/sixty-carpets-unite.md
+++ b/.changeset/sixty-carpets-unite.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": patch
+---
+
+Thread `--verbose` through `resolveConfig()` everywhere

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,7 +435,7 @@ Config files are written with permissions `0o660`.
 
 ### Config resolution precedence
 
-When resolving the active configuration (in `resolveConfig(profile, apiKeyOverride?)`), the following priority applies — highest wins:
+When resolving the active configuration (in `resolveConfig(profile, apiKeyOverride?, verbose?)`), the following priority applies — highest wins:
 
 1. **`--api-key` flag** — Passed as `apiKeyOverride` to `resolveConfig()`
 2. **Environment variables** — `BUNNYNET_API_KEY` and `BUNNYNET_API_URL`
@@ -911,7 +911,7 @@ import { resolveConfig } from "../../config/index.ts";
 import { clientOptions } from "../../core/client-options.ts";
 
 handler: async ({ profile, apiKey, verbose }) => {
-  const config = resolveConfig(profile, apiKey);
+  const config = resolveConfig(profile, apiKey, verbose);
   const api = createCoreClient(clientOptions(config, verbose));
 
   const { data, error } = await api.GET("/pullzone/{id}", {
@@ -1152,7 +1152,7 @@ bunny db shell seed.sql
 4. **Add flag equivalents for every interactive prompt** so the command is fully scriptable (see "Agent & Scripting Compatibility").
 5. Use `preRun` for validation that should prevent execution.
 6. Access global flags (`profile`, `verbose`, `output`) directly from the args object.
-7. Resolve config via `resolveConfig(args.profile, args.apiKey)` when API access is needed.
+7. Resolve config via `resolveConfig(args.profile, args.apiKey, args.verbose)` when API access is needed.
 8. Use `logger` for all output. **Every command that returns data must support `--output json`.**
 9. Throw `UserError` for expected failures. Let unexpected errors propagate to the factory's catch block.
 10. Register the new command/namespace in `packages/cli/src/cli.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ This is a Bun workspace monorepo with four packages:
 - See `AGENTS.md` for full architecture documentation.
 - Commands use `defineCommand()` from `packages/cli/src/core/define-command.ts`.
 - Namespaces use `defineNamespace()` from `packages/cli/src/core/define-namespace.ts`.
-- Resolve config via `resolveConfig(profile, apiKey)` — always pass both args.
+- Resolve config via `resolveConfig(profile, apiKey, verbose)` — always pass `profile` and `apiKey`; pass `verbose` so credential-source debug lines respect the flag.
 - Use `formatTable()` / `formatKeyValue()` from `packages/cli/src/core/format.ts` for non-JSON output.
 - Handle `--output json` first in every handler, then pass `output` to format functions.
 - Use `logger` from `packages/cli/src/core/logger.ts` for all user-facing output.

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -94,7 +94,7 @@ export const apiCommand = defineCommand<ApiArgs>({
       );
     }
 
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     if (!config.apiKey) {
       throw new UserError(
         "Not logged in.",

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -32,7 +32,7 @@ export const appsDeleteCommand = defineCommand<DeleteArgs>({
 
   handler: async ({ id: rawId, force, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     if (!force) {

--- a/packages/cli/src/commands/apps/deploy.ts
+++ b/packages/cli/src/commands/apps/deploy.ts
@@ -39,7 +39,7 @@ export const appsDeployCommand = defineCommand<DeployArgs>({
 
   handler: async ({ image, profile, output, verbose, apiKey }) => {
     const toml = loadConfig();
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     let appId = toml.app.id;

--- a/packages/cli/src/commands/apps/endpoints/add.ts
+++ b/packages/cli/src/commands/apps/endpoints/add.ts
@@ -65,7 +65,7 @@ export const appsEndpointsAddCommand = defineCommand<AddArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const { data: app } = await client.GET("/apps/{appId}", {

--- a/packages/cli/src/commands/apps/endpoints/list.ts
+++ b/packages/cli/src/commands/apps/endpoints/list.ts
@@ -40,7 +40,7 @@ export const appsEndpointsListCommand = defineCommand<ListArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching endpoints...");

--- a/packages/cli/src/commands/apps/endpoints/remove.ts
+++ b/packages/cli/src/commands/apps/endpoints/remove.ts
@@ -46,7 +46,7 @@ export const appsEndpointsRemoveCommand = defineCommand<RemoveArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     if (!force) {

--- a/packages/cli/src/commands/apps/env/list.ts
+++ b/packages/cli/src/commands/apps/env/list.ts
@@ -40,7 +40,7 @@ export const appsEnvListCommand = defineCommand<ListArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching environment variables...");

--- a/packages/cli/src/commands/apps/env/pull.ts
+++ b/packages/cli/src/commands/apps/env/pull.ts
@@ -48,7 +48,7 @@ export const appsEnvPullCommand = defineCommand<PullArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching environment variables...");

--- a/packages/cli/src/commands/apps/env/remove.ts
+++ b/packages/cli/src/commands/apps/env/remove.ts
@@ -46,7 +46,7 @@ export const appsEnvRemoveCommand = defineCommand<RemoveArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching current variables...");

--- a/packages/cli/src/commands/apps/env/set.ts
+++ b/packages/cli/src/commands/apps/env/set.ts
@@ -53,7 +53,7 @@ export const appsEnvSetCommand = defineCommand<SetArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     // Read-modify-write: fetch current vars, update, PUT all

--- a/packages/cli/src/commands/apps/init.ts
+++ b/packages/cli/src/commands/apps/init.ts
@@ -64,7 +64,7 @@ export const appsInitCommand = defineCommand<InitArgs>({
     }
     if (!name) throw new UserError("App name is required.");
 
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     // Detect Dockerfile in cwd

--- a/packages/cli/src/commands/apps/list.ts
+++ b/packages/cli/src/commands/apps/list.ts
@@ -16,7 +16,7 @@ export const appsListCommand = defineCommand({
   aliases: ["ls"],
 
   handler: async ({ profile, output, verbose, apiKey }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching apps...");

--- a/packages/cli/src/commands/apps/pull.ts
+++ b/packages/cli/src/commands/apps/pull.ts
@@ -37,7 +37,7 @@ export const appsPullCommand = defineCommand<PullArgs>({
 
   handler: async ({ id: rawId, force, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     if (configExists() && !force) {

--- a/packages/cli/src/commands/apps/push.ts
+++ b/packages/cli/src/commands/apps/push.ts
@@ -26,7 +26,7 @@ export const appsPushCommand = defineCommand<PushArgs>({
   handler: async ({ "dry-run": dryRun, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId();
     const toml = loadConfig();
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching current app state...");

--- a/packages/cli/src/commands/apps/regions/list.ts
+++ b/packages/cli/src/commands/apps/regions/list.ts
@@ -15,7 +15,7 @@ export const appsRegionsListCommand = defineCommand({
   aliases: ["ls"],
 
   handler: async ({ profile, output, verbose, apiKey }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching regions...");

--- a/packages/cli/src/commands/apps/regions/show.ts
+++ b/packages/cli/src/commands/apps/regions/show.ts
@@ -26,7 +26,7 @@ export const appsRegionsShowCommand = defineCommand<ShowArgs>({
 
   handler: async ({ id: rawId, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching region settings...");

--- a/packages/cli/src/commands/apps/restart.ts
+++ b/packages/cli/src/commands/apps/restart.ts
@@ -25,7 +25,7 @@ export const appsRestartCommand = defineCommand<RestartArgs>({
 
   handler: async ({ id: rawId, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Restarting app...");

--- a/packages/cli/src/commands/apps/show.ts
+++ b/packages/cli/src/commands/apps/show.ts
@@ -27,7 +27,7 @@ export const appsShowCommand = defineCommand<ShowArgs>({
 
   handler: async ({ id: rawId, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching app...");

--- a/packages/cli/src/commands/apps/undeploy.ts
+++ b/packages/cli/src/commands/apps/undeploy.ts
@@ -32,7 +32,7 @@ export const appsUndeployCommand = defineCommand<UndeployArgs>({
 
   handler: async ({ id: rawId, force, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     if (!force) {

--- a/packages/cli/src/commands/apps/volumes/list.ts
+++ b/packages/cli/src/commands/apps/volumes/list.ts
@@ -27,7 +27,7 @@ export const appsVolumesListCommand = defineCommand<ListArgs>({
 
   handler: async ({ id: rawId, profile, output, verbose, apiKey }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching volumes...");

--- a/packages/cli/src/commands/apps/volumes/remove.ts
+++ b/packages/cli/src/commands/apps/volumes/remove.ts
@@ -46,7 +46,7 @@ export const appsVolumesRemoveCommand = defineCommand<RemoveArgs>({
     apiKey,
   }) => {
     const appId = resolveAppId(rawId);
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     if (!force) {

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -150,7 +150,7 @@ export const authLoginCommand = defineCommand<{ force: boolean }>({
       setProfile(profile, apiKey);
 
       // Fetch user details for a personalised greeting
-      const config = resolveConfig(profile);
+      const config = resolveConfig(profile, undefined, verbose);
       const client = createCoreClient(clientOptions(config, verbose));
 
       const spin = spinner("Verifying credentials...");

--- a/packages/cli/src/commands/config/show.ts
+++ b/packages/cli/src/commands/config/show.ts
@@ -7,8 +7,8 @@ export const configShowCommand = defineCommand({
   command: "show",
   describe: "Show the loaded configuration.",
 
-  handler: async ({ profile, output, apiKey }) => {
-    const cfg = resolveConfig(profile, apiKey);
+  handler: async ({ profile, output, apiKey, verbose }) => {
+    const cfg = resolveConfig(profile, apiKey, verbose);
 
     if (output === "json") {
       const { apiKey: rawKey, ...rest } = cfg;

--- a/packages/cli/src/commands/db/create.ts
+++ b/packages/cli/src/commands/db/create.ts
@@ -127,7 +127,7 @@ export const dbCreateCommand = defineCommand<CreateArgs>({
 
   handler: async (args) => {
     const { profile, output, verbose, apiKey } = args;
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     // Step 1: Database name

--- a/packages/cli/src/commands/db/delete.ts
+++ b/packages/cli/src/commands/db/delete.ts
@@ -84,7 +84,7 @@ export const dbDeleteCommand = defineCommand<DeleteArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const { id: databaseId, source } = await resolveDbId(client, databaseIdArg);

--- a/packages/cli/src/commands/db/link.ts
+++ b/packages/cli/src/commands/db/link.ts
@@ -59,7 +59,7 @@ export const dbLinkCommand = defineCommand<LinkArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     if (databaseIdArg) {

--- a/packages/cli/src/commands/db/list.ts
+++ b/packages/cli/src/commands/db/list.ts
@@ -40,7 +40,7 @@ export const dbListCommand = defineCommand({
   describe: DESCRIPTION,
 
   handler: async ({ profile, output, verbose, apiKey }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching databases...");

--- a/packages/cli/src/commands/db/quickstart.ts
+++ b/packages/cli/src/commands/db/quickstart.ts
@@ -225,7 +225,7 @@ export const dbQuickstartCommand = defineCommand<{
 
     // Resolve URL and token from API if not provided via flags
     if (!url || !token) {
-      const config = resolveConfig(profile, apiKey);
+      const config = resolveConfig(profile, apiKey, verbose);
       const client = createDbClient(clientOptions(config, verbose));
 
       const { id: databaseId } = await resolveDbId(client, databaseIdArg);

--- a/packages/cli/src/commands/db/regions/add.ts
+++ b/packages/cli/src/commands/db/regions/add.ts
@@ -82,7 +82,7 @@ export const dbRegionsAddCommand = defineCommand<AddArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const { id: databaseId } = await resolveDbId(client, databaseIdArg);

--- a/packages/cli/src/commands/db/regions/list.ts
+++ b/packages/cli/src/commands/db/regions/list.ts
@@ -46,7 +46,7 @@ export const dbRegionsListCommand = defineCommand<ListArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const { id: databaseId } = await resolveDbId(client, databaseIdArg);

--- a/packages/cli/src/commands/db/regions/remove.ts
+++ b/packages/cli/src/commands/db/regions/remove.ts
@@ -90,7 +90,7 @@ export const dbRegionsRemoveCommand = defineCommand<RemoveArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const { id: databaseId } = await resolveDbId(client, databaseIdArg);

--- a/packages/cli/src/commands/db/regions/update.ts
+++ b/packages/cli/src/commands/db/regions/update.ts
@@ -70,7 +70,7 @@ export const dbRegionsUpdateCommand = defineCommand<UpdateArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const { id: databaseId } = await resolveDbId(client, databaseIdArg);

--- a/packages/cli/src/commands/db/shell.ts
+++ b/packages/cli/src/commands/db/shell.ts
@@ -71,7 +71,7 @@ async function resolveCredentials(
     return { url, token, databaseId: databaseIdArg, tokenGenerated: false };
   }
 
-  const config = resolveConfig(profile, apiKeyOverride);
+  const config = resolveConfig(profile, apiKeyOverride, verbose);
   const apiClient = createDbClient(clientOptions(config, verbose));
 
   const { id: databaseId } = await resolveDbId(apiClient, databaseIdArg);

--- a/packages/cli/src/commands/db/show.ts
+++ b/packages/cli/src/commands/db/show.ts
@@ -52,7 +52,7 @@ export const dbShowCommand = defineCommand<ShowArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const { id: databaseId } = await resolveDbId(client, databaseIdArg);

--- a/packages/cli/src/commands/db/studio.ts
+++ b/packages/cli/src/commands/db/studio.ts
@@ -42,7 +42,7 @@ async function resolveCredentials(
 
   if (url && token) return { url, token, databaseId: databaseIdArg };
 
-  const config = resolveConfig(profile, apiKeyOverride);
+  const config = resolveConfig(profile, apiKeyOverride, verbose);
   const apiClient = createDbClient(clientOptions(config, verbose));
 
   const { id: databaseId } = await resolveDbId(apiClient, databaseIdArg);

--- a/packages/cli/src/commands/db/tokens/create.ts
+++ b/packages/cli/src/commands/db/tokens/create.ts
@@ -156,7 +156,7 @@ export const dbTokensCreateCommand = defineCommand<{
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     const authorization = readOnly ? "read-only" : "full-access";

--- a/packages/cli/src/commands/db/tokens/invalidate.ts
+++ b/packages/cli/src/commands/db/tokens/invalidate.ts
@@ -107,7 +107,7 @@ export const dbTokensInvalidateCommand = defineCommand<{
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     // Resolve the target database — explicit ID, .env, or interactive prompt

--- a/packages/cli/src/commands/db/usage.ts
+++ b/packages/cli/src/commands/db/usage.ts
@@ -128,7 +128,7 @@ export const dbUsageCommand = defineCommand<UsageArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createDbClient(clientOptions(config, verbose));
 
     // Resolve time range

--- a/packages/cli/src/commands/registries/add.ts
+++ b/packages/cli/src/commands/registries/add.ts
@@ -83,7 +83,7 @@ export const registryAddCommand = defineCommand<AddArgs>({
     }
     if (!password) throw new UserError("Password is required.");
 
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Adding registry...");

--- a/packages/cli/src/commands/registries/list.ts
+++ b/packages/cli/src/commands/registries/list.ts
@@ -15,7 +15,7 @@ export const registryListCommand = defineCommand({
   aliases: ["ls"],
 
   handler: async ({ profile, output, verbose, apiKey }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching registries...");

--- a/packages/cli/src/commands/registries/remove.ts
+++ b/packages/cli/src/commands/registries/remove.ts
@@ -39,7 +39,7 @@ export const registryRemoveCommand = defineCommand<RemoveArgs>({
     verbose,
     apiKey,
   }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createMcClient(clientOptions(config, verbose));
 
     if (!force) {

--- a/packages/cli/src/commands/scripts/create.ts
+++ b/packages/cli/src/commands/scripts/create.ts
@@ -61,7 +61,7 @@ export async function createScript(opts: {
   createLinkedPullZone: boolean;
   linkedPullZoneName?: string;
 }): Promise<CreatedScript> {
-  const config = resolveConfig(opts.profile, opts.apiKey);
+  const config = resolveConfig(opts.profile, opts.apiKey, opts.verbose);
   const client = createComputeClient(clientOptions(config, opts.verbose));
 
   const spin = spinner(`Creating script "${opts.name}"...`);

--- a/packages/cli/src/commands/scripts/delete.ts
+++ b/packages/cli/src/commands/scripts/delete.ts
@@ -79,7 +79,7 @@ export const scriptsDeleteCommand = defineCommand<DeleteArgs>({
     apiKey,
   }) => {
     const id = resolveManifestId(SCRIPT_MANIFEST, rawId, "script");
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const fetchSpin = spinner("Fetching Edge Script...");

--- a/packages/cli/src/commands/scripts/deploy.ts
+++ b/packages/cli/src/commands/scripts/deploy.ts
@@ -91,7 +91,7 @@ export const scriptsDeployCommand = defineCommand<DeployArgs>({
 
     const code = await Bun.file(absPath).text();
 
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Uploading code...");

--- a/packages/cli/src/commands/scripts/deployments/list.ts
+++ b/packages/cli/src/commands/scripts/deployments/list.ts
@@ -74,7 +74,7 @@ export const scriptsDeploymentsListCommand = defineCommand<ListArgs>({
 
   handler: async ({ [ARG_ID]: rawId, profile, output, verbose, apiKey }) => {
     const id = resolveManifestId(SCRIPT_MANIFEST, rawId, "script");
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching deployments...");

--- a/packages/cli/src/commands/scripts/env/list.ts
+++ b/packages/cli/src/commands/scripts/env/list.ts
@@ -63,7 +63,7 @@ export const scriptsEnvListCommand = defineCommand<ListArgs>({
 
   handler: async ({ [ARG_ID]: rawId, profile, output, verbose, apiKey }) => {
     const id = resolveManifestId(SCRIPT_MANIFEST, rawId, "script");
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching environment variables...");

--- a/packages/cli/src/commands/scripts/env/pull.ts
+++ b/packages/cli/src/commands/scripts/env/pull.ts
@@ -75,7 +75,7 @@ export const scriptsEnvPullCommand = defineCommand<PullArgs>({
     apiKey,
   }) => {
     const id = resolveManifestId(SCRIPT_MANIFEST, rawId, "script");
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching environment variables...");

--- a/packages/cli/src/commands/scripts/env/remove.ts
+++ b/packages/cli/src/commands/scripts/env/remove.ts
@@ -99,7 +99,7 @@ export const scriptsEnvRemoveCommand = defineCommand<RemoveArgs>({
     apiKey,
   }) => {
     const id = resolveManifestId(SCRIPT_MANIFEST, rawId, "script");
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching environment variables...");

--- a/packages/cli/src/commands/scripts/env/set.ts
+++ b/packages/cli/src/commands/scripts/env/set.ts
@@ -135,7 +135,7 @@ export const scriptsEnvSetCommand = defineCommand<SetArgs>({
 
     name = name.toUpperCase();
 
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Checking for conflicts...");

--- a/packages/cli/src/commands/scripts/link.ts
+++ b/packages/cli/src/commands/scripts/link.ts
@@ -59,7 +59,7 @@ export const scriptsLinkCommand = defineCommand<LinkArgs>({
     }),
 
   handler: async ({ [ARG_ID]: id, profile, output, verbose, apiKey }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     if (id) {

--- a/packages/cli/src/commands/scripts/list.ts
+++ b/packages/cli/src/commands/scripts/list.ts
@@ -37,7 +37,7 @@ export const scriptsListCommand = defineCommand({
   ],
 
   handler: async ({ profile, output, verbose, apiKey }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching Edge Scripts...");

--- a/packages/cli/src/commands/scripts/show.ts
+++ b/packages/cli/src/commands/scripts/show.ts
@@ -57,7 +57,7 @@ export const scriptsShowCommand = defineCommand<ShowArgs>({
 
   handler: async ({ [ARG_ID]: rawId, profile, output, verbose, apiKey }) => {
     const id = resolveManifestId(SCRIPT_MANIFEST, rawId, "script");
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
     const client = createComputeClient(clientOptions(config, verbose));
 
     const spin = spinner("Fetching Edge Script...");

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -34,7 +34,7 @@ export const whoamiCommand = defineCommand({
   ],
 
   handler: async ({ profile, output, verbose, apiKey }) => {
-    const config = resolveConfig(profile, apiKey);
+    const config = resolveConfig(profile, apiKey, verbose);
 
     if (!config.apiKey) {
       throw new UserError(


### PR DESCRIPTION
Follow-up to #76 @twogood 🚀 

That PR added an optional `verbose` parameter to `resolveConfig()` but no caller passed it, so the `[debug] API key loaded from …` lines stayed silent even when the user supplied `--verbose`.