### PR TITLE
fix(sandbox): drop inherited tsconfig paths in package build

### DIFF
--- a/packages/sandbox/tsconfig.build.json
+++ b/packages/sandbox/tsconfig.build.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "rewriteRelativeImportExtensions": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "paths": {}
   },
   "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/sandbox/tsconfig.build.json
+++ b/packages/sandbox/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declaration": true,
     "rewriteRelativeImportExtensions": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    // Drop the root tsconfig's source paths so openapi-client resolves via its dist exports (build it first)
+    "paths": {}
   },
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

The sandbox publish job failed in the release workflow ([run 29016270633](https://github.com/BunnyWay/cli/actions/runs/29016270633/job/86112044090)) with dozens of TS6059 errors: openapi-client source files are "not under rootDir".

The root `tsconfig.json` maps `@bunny.net/openapi-client` to `packages/openapi-client/src` via `paths` so the repo works without a prebuild step. `packages/sandbox/tsconfig.build.json` extends the root config and inherited that mapping, so `tsc` pulled the client's sources into the sandbox program and tripped the `rootDir: src` check, even though the workflow builds openapi-client's dist first.

## Fix

Override `paths` to `{}` in `packages/sandbox/tsconfig.build.json`. The package build now resolves `@bunny.net/openapi-client` through its package exports (`dist/`), the same way npm consumers do. The workflow already builds openapi-client before sandbox, so dist is present.

Verified locally: `bun run --filter @bunny.net/sandbox build` reproduces the CI failure before the change and passes after, emitted `.d.ts` files reference `@bunny.net/openapi-client` by name (no relative paths into the sibling package), and the root `tsc --noEmit` still passes.

No changeset needed: once merged, the release workflow re-runs on main and picks up the still-unpublished sandbox 0.3.0.