### PR TITLE
chore(sandbox): install uv and add /workplace/bin to the PATH

### DIFF
--- a/.changeset/sandbox-uv-workplace-bin.md
+++ b/.changeset/sandbox-uv-workplace-bin.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": patch
+---
+
+chore(sandbox): install uv in the sandbox image and add /workplace/bin to the PATH

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -931,7 +931,9 @@ A deploy's preview URL is `sites-<name>-<suffix>.b-cdn.net/deploys/<id>/`. Becau
 
 ### `bunny sandbox`
 
-Manage on-demand cloud sandbox environments backed by Bunny Magic Containers. Each sandbox is a fully isolated Ubuntu container with Node.js, Bun, Python, the bunny CLI, and Claude Code pre-installed, alongside the tooling agents reach for: `git`, `gh`, `ripgrep`, `fd`, `jq`, `tmux`, `sqlite3`, `tree`, and `fzf`. A 10 GB persistent volume is mounted at `/workplace`, your default working directory.
+Manage on-demand cloud sandbox environments backed by Bunny Magic Containers. Each sandbox is a fully isolated Ubuntu container with Node.js, Bun, Python (plus `uv`), the bunny CLI, and Claude Code pre-installed, alongside the tooling agents reach for: `git`, `gh`, `ripgrep`, `fd`, `jq`, `tmux`, `sqlite3`, `tree`, and `fzf`. A 10 GB persistent volume is mounted at `/workplace`, your default working directory.
+
+`/workplace/bin` is included in the PATH, so anything you put there runs by name after a redeploy without an absolute path.
 
 Claude Code is pre-installed but needs your own Anthropic credentials before it can do anything: pass an API key at create time (prefer `--env-file .env` so the key stays out of your shell history), or run `claude` inside the sandbox and complete the login prompt it prints. Both survive restarts and redeploys: baked env vars live on the container, and config and credentials are pinned to the persistent volume — `/workplace/.claude` for Claude Code, and `/workplace/.config` for the bunny CLI and `gh`.
 

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -107,8 +107,8 @@ RUN npm install -g @bunny.net/cli@latest \
 
 # Workplace — SSH sessions land here, and Claude Code, the bunny CLI and gh all
 # keep their config and credentials on the persistent volume (the latter two via
-# XDG_CONFIG_HOME, which they both honour). /workplace/bin leads the PATH, so
-# user scripts placed there run by name and survive a redeploy.
+# XDG_CONFIG_HOME, which they both honour). /workplace/bin is on the PATH after
+# system directories.
 #
 # These have to go in /etc/environment, not just ENV: sshd builds a fresh
 # environment per session, so Docker ENV never reaches an SSH login. pam_env
@@ -118,10 +118,10 @@ RUN npm install -g @bunny.net/cli@latest \
 # see the same values.
 ENV CLAUDE_CONFIG_DIR=/workplace/.claude \
     XDG_CONFIG_HOME=/workplace/.config
-ENV PATH="/workplace/bin:$PATH"
+ENV PATH="$PATH:/workplace/bin"
 RUN mkdir -p /workplace \
     && printf '%s\n' \
-        'PATH=/workplace/bin:/root/.local/bin:/root/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
+        'PATH=/root/.local/bin:/root/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workplace/bin' \
         'LANG=C.UTF-8' \
         'CLAUDE_CONFIG_DIR=/workplace/.claude' \
         'XDG_CONFIG_HOME=/workplace/.config' \

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -108,8 +108,7 @@ RUN npm install -g @bunny.net/cli@latest \
 # Workplace — SSH sessions land here, and Claude Code, the bunny CLI and gh all
 # keep their config and credentials on the persistent volume (the latter two via
 # XDG_CONFIG_HOME, which they both honour). /workplace/bin leads the PATH, so
-# anything dropped there — a uv tool redirected with UV_TOOL_BIN_DIR, a script
-# of your own — runs by name and survives a redeploy.
+# user scripts placed there run by name and survive a redeploy.
 #
 # These have to go in /etc/environment, not just ENV: sshd builds a fresh
 # environment per session, so Docker ENV never reaches an SSH login. pam_env

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -69,6 +69,21 @@ RUN set -eux; \
     rm -rf /tmp/bun.zip /tmp/bun
 ENV PATH="/root/.bun/bin:$PATH"
 
+# uv — Python package and project manager
+ARG UV_VERSION=0.12.1
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) UV_ARCH=x86_64;    UV_SHA256=90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb ;; \
+        arm64) UV_ARCH=aarch64;   UV_SHA256=769d373e146692c639b5fbaae33b331c297a32e03d30448772051902df52bbf4 ;; \
+        *) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/uv.tar.gz; \
+    echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/uv.tar.gz -C /tmp; \
+    install -Dm755 "/tmp/uv-${UV_ARCH}-unknown-linux-gnu/uv" /usr/local/bin/uv; \
+    install -Dm755 "/tmp/uv-${UV_ARCH}-unknown-linux-gnu/uvx" /usr/local/bin/uvx; \
+    rm -rf /tmp/uv.tar.gz "/tmp/uv-${UV_ARCH}-unknown-linux-gnu"
+
 # Claude Code — official installer, always the newest release.
 # Installs the launcher into /root/.local/bin; the installer itself
 # checksum-verifies the binary it downloads.
@@ -92,7 +107,9 @@ RUN npm install -g @bunny.net/cli@latest \
 
 # Workplace — SSH sessions land here, and Claude Code, the bunny CLI and gh all
 # keep their config and credentials on the persistent volume (the latter two via
-# XDG_CONFIG_HOME, which they both honour).
+# XDG_CONFIG_HOME, which they both honour). /workplace/bin leads the PATH, so
+# anything dropped there — a uv tool redirected with UV_TOOL_BIN_DIR, a script
+# of your own — runs by name and survives a redeploy.
 #
 # These have to go in /etc/environment, not just ENV: sshd builds a fresh
 # environment per session, so Docker ENV never reaches an SSH login. pam_env
@@ -102,9 +119,10 @@ RUN npm install -g @bunny.net/cli@latest \
 # see the same values.
 ENV CLAUDE_CONFIG_DIR=/workplace/.claude \
     XDG_CONFIG_HOME=/workplace/.config
+ENV PATH="/workplace/bin:$PATH"
 RUN mkdir -p /workplace \
     && printf '%s\n' \
-        'PATH=/root/.local/bin:/root/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
+        'PATH=/workplace/bin:/root/.local/bin:/root/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
         'LANG=C.UTF-8' \
         'CLAUDE_CONFIG_DIR=/workplace/.claude' \
         'XDG_CONFIG_HOME=/workplace/.config' \

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -12,6 +12,7 @@ echo "root:${AGENT_TOKEN}" | chpasswd
 # config directories have to be created here — anything created at build time is
 # hidden by the mount.
 mkdir -p /workplace/.claude \
-         /workplace/.config
+         /workplace/.config \
+         /workplace/bin
 
 exec /usr/sbin/sshd -D

--- a/skills/bunny-cli/references/sandbox.md
+++ b/skills/bunny-cli/references/sandbox.md
@@ -1,6 +1,6 @@
 # Sandbox Commands
 
-All sandbox commands live under `bunny sandbox`. Each sandbox is a fully isolated Ubuntu container (Bunny Magic Containers) with Node.js, Bun, Python, the bunny CLI, and Claude Code pre-installed, alongside the tooling agents reach for: `git`, `gh`, `ripgrep`, `fd`, `jq`, `tmux`, `sqlite3`, `tree`, and `fzf`. A 10 GB persistent volume is mounted at `/workplace`, the default working directory; relative remote paths resolve against it.
+All sandbox commands live under `bunny sandbox`. Each sandbox is a fully isolated Ubuntu container (Bunny Magic Containers) with Node.js, Bun, Python (plus `uv`), the bunny CLI, and Claude Code pre-installed, alongside the tooling agents reach for: `git`, `gh`, `ripgrep`, `fd`, `jq`, `tmux`, `sqlite3`, `tree`, and `fzf`. A 10 GB persistent volume is mounted at `/workplace`, the default working directory; relative remote paths resolve against it.
 
 Sandbox credentials (app ID, SSH endpoint, agent token) are stored in the CLI's local config (same candidate paths as in SKILL.md), so commands reference sandboxes by name.
 


### PR DESCRIPTION
Since we already ship Python, add the uv package manager to the sandbox image.

Also include /workplace/bin in the default PATH, so that users can have tools that survive a redeploy.