### PR TITLE
fix(cli): prevent truncated JSON output when piped

### DIFF
--- a/.changeset/fix-piped-json-output.md
+++ b/.changeset/fix-piped-json-output.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": patch
+---
+
+Prevent JSON output from being truncated when piped.

--- a/packages/cli/src/core/logger.ts
+++ b/packages/cli/src/core/logger.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { bunny } from "./colors.ts";
 
 export const logger = {
-  log: (msg = "") => console.log(msg),
+  log: (msg = "") => process.stdout.write(`${msg}\n`, () => {}),
   info: (msg: string) => console.error(bunny("ℹ"), msg),
   success: (msg: string, symbolColor: (text: string) => string = chalk.green) =>
     console.error(symbolColor("✓"), msg),


### PR DESCRIPTION
Write JSON directly to stdout and wait for the write to complete.

In Bun, console.log can leave large output truncated when stdout is piped and the CLI process exits before the pipe drains.

Fixes #151