### PR TITLE
chore(openapi): refresh specs and repoint everything at bunny.net/docs

### DIFF
--- a/.changeset/anycast-ip-protocol-version.md
+++ b/.changeset/anycast-ip-protocol-version.md
@@ -1,0 +1,6 @@
+---
+"@bunny.net/cli": patch
+"@bunny.net/sandbox": patch
+---
+
+anycast endpoints now send the `iPv4` IP protocol version documented by the Magic Containers API

--- a/.changeset/docs-urls-bunny-net-docs.md
+++ b/.changeset/docs-urls-bunny-net-docs.md
@@ -1,0 +1,6 @@
+---
+"@bunny.net/cli": patch
+"@bunny.net/scriptable-dns-types": patch
+---
+
+point documentation links at bunny.net/docs, including the Scriptable DNS link that had gone dead

--- a/.changeset/openapi-specs-refresh.md
+++ b/.changeset/openapi-specs-refresh.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/openapi-client": patch
+---
+
+refresh OpenAPI specs from the sources listed at https://bunny.net/docs/openapi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1213,12 +1213,18 @@ Only fall back to `string`, `any`, or `number` when no generated type exists (e.
 
 Specs are committed as JSON files in `packages/openapi-client/specs/`. Generated types go to `packages/openapi-client/src/generated/` (gitignored). The `redocly.yaml` config and `openapi-typescript` devDependency live in the `@bunny.net/openapi-client` package.
 
-| Spec file                                             | Source URL                                                    |
-| ----------------------------------------------------- | ------------------------------------------------------------- |
-| `packages/openapi-client/specs/core.json`             | `https://core-api-public-docs.b-cdn.net/docs/v3/public.json`  |
-| `packages/openapi-client/specs/compute.json`          | `https://core-api-public-docs.b-cdn.net/docs/v3/compute.json` |
-| `packages/openapi-client/specs/database.json`         | `https://api.bunny.net/database/docs/private/api.json`        |
-| `packages/openapi-client/specs/magic-containers.json` | `https://api-mc.opsbunny.net/docs/public/swagger.json`        |
+Source URLs are listed at https://bunny.net/docs/openapi; `scripts/update-specs.ts` is the authority for which ones this repo pulls.
+
+| Spec file                                             | Source URL                                                          |
+| ----------------------------------------------------- | ------------------------------------------------------------------- |
+| `packages/openapi-client/specs/core.json`             | `https://core-api-public-docs.b-cdn.net/docs/v3/public.json`        |
+| `packages/openapi-client/specs/compute.json`          | `https://core-api-public-docs.b-cdn.net/docs/v3/compute.json`       |
+| `packages/openapi-client/specs/database.json`         | `https://api.bunny.net/database/docs/private/api.json`              |
+| `packages/openapi-client/specs/magic-containers.json` | `https://api-mc.opsbunny.net/docs/public/swagger.json`              |
+| `packages/openapi-client/specs/origin-errors.json`    | `https://bunny.net/docs/api-reference/origin-errors/openapi.json`   |
+| `packages/openapi-client/specs/shield.json`           | `https://api.bunny.net/shield/docs/v1/swagger.json`                 |
+| `packages/openapi-client/specs/storage.json`          | `https://bunny.net/docs/api-reference/storage/openapi.json`         |
+| `packages/openapi-client/specs/stream.json`           | `https://video.bunnycdn.com/openapi/bunnynet-video-api.public.json` |
 
 To regenerate types after updating specs:
 

--- a/packages/cli/src/commands/apps/endpoints/add.ts
+++ b/packages/cli/src/commands/apps/endpoints/add.ts
@@ -133,7 +133,7 @@ export const appsEndpointsAddCommand = defineCommand<AddArgs>({
       };
     } else {
       body.anycast = {
-        type: "ipv4",
+        type: "iPv4",
         portMappings: [{ containerPort: cPort, exposedPort: pPort }],
       };
     }

--- a/packages/cli/src/commands/apps/endpoints/format.test.ts
+++ b/packages/cli/src/commands/apps/endpoints/format.test.ts
@@ -8,6 +8,7 @@ import {
 /** Build a ContainerEndpoint with sane defaults for the fields we don't test. */
 function endpoint(over: Partial<ContainerEndpoint>): ContainerEndpoint {
   return {
+    id: "ep_1",
     displayName: "cdn",
     publicHost: "",
     type: "cdn",

--- a/packages/cli/src/commands/apps/suggestions.test.ts
+++ b/packages/cli/src/commands/apps/suggestions.test.ts
@@ -114,7 +114,7 @@ describe("endpointRequestToConfig", () => {
     const ep: EndpointRequest = {
       displayName: "anycast",
       anycast: {
-        type: "ipv4",
+        type: "iPv4",
         portMappings: [{ exposedPort: 9090, containerPort: 9090 }],
       },
     };

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -2,7 +2,7 @@ import { defineCommand } from "../core/define-command.ts";
 import { logger } from "../core/logger.ts";
 import { openBrowser } from "../core/ui.ts";
 
-export const DOCS_BASE_URL = "https://docs.bunny.net";
+export const DOCS_BASE_URL = "https://bunny.net/docs";
 
 const COMMAND = "docs";
 const DESCRIPTION = "Open bunny.net documentation in the browser.";

--- a/packages/config/src/convert.test.ts
+++ b/packages/config/src/convert.test.ts
@@ -125,6 +125,7 @@ describe("apiToConfig", () => {
           template({
             endpoints: [
               {
+                id: "ep_1",
                 displayName: "web",
                 publicHost: "example.com",
                 type: "cdn",
@@ -339,7 +340,7 @@ describe("configToAddRequest", () => {
     ]);
   });
 
-  test("anycast endpoint stamps type 'ipv4'", () => {
+  test("anycast endpoint stamps type 'iPv4'", () => {
     const req = configToAddRequest({
       version: CURRENT_VERSION,
       app: {
@@ -355,7 +356,7 @@ describe("configToAddRequest", () => {
       },
     });
     const ep = req.containerTemplates?.[0]?.endpoints?.[0];
-    expect(ep?.anycast?.type).toBe("ipv4");
+    expect(ep?.anycast?.type).toBe("iPv4");
     expect(ep?.anycast?.portMappings).toEqual([
       { containerPort: 80, exposedPort: 80 },
     ]);

--- a/packages/config/src/convert.ts
+++ b/packages/config/src/convert.ts
@@ -162,7 +162,7 @@ function endpointConfigToRequest(ep: EndpointConfig): EndpointRequest {
     };
   } else if (ep.type === "anycast") {
     req.anycast = {
-      type: "ipv4",
+      type: "iPv4",
       portMappings: (ep.ports ?? []).map((p) => ({
         containerPort: p.container,
         exposedPort: p.public,

--- a/packages/openapi-client/scripts/update-specs.ts
+++ b/packages/openapi-client/scripts/update-specs.ts
@@ -26,12 +26,12 @@ const specs = [
   },
   {
     name: "origin-errors",
-    url: "https://docs.bunny.net/api-reference/origin-errors/openapi.json",
+    url: "https://bunny.net/docs/api-reference/origin-errors/openapi.json",
     out: "specs/origin-errors.json",
   },
   {
     name: "storage",
-    url: "https://docs.bunny.net/api-reference/storage/openapi.json",
+    url: "https://bunny.net/docs/api-reference/storage/openapi.json",
     out: "specs/storage.json",
   },
   {

--- a/packages/openapi-client/specs/compute.json
+++ b/packages/openapi-client/specs/compute.json
@@ -71,7 +71,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -82,7 +83,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -139,7 +141,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -150,7 +153,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -217,7 +221,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -228,7 +233,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -280,7 +286,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -291,7 +298,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -356,7 +364,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -367,7 +376,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -463,7 +473,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -474,7 +485,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -584,7 +596,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -595,7 +608,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -653,7 +667,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -664,7 +679,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -711,7 +727,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -722,7 +739,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -789,7 +807,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -800,7 +819,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -868,7 +888,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -879,7 +900,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -942,7 +964,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -953,7 +976,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1029,7 +1053,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1040,7 +1065,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1117,7 +1143,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1128,7 +1155,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1205,7 +1233,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1216,7 +1245,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1265,7 +1295,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1276,7 +1307,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1354,7 +1386,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1365,7 +1398,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1433,7 +1467,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1444,7 +1479,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1530,7 +1566,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1541,7 +1578,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1595,7 +1633,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1606,7 +1645,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1684,7 +1724,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1695,7 +1736,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1768,7 +1810,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1779,7 +1822,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -1852,7 +1896,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -1863,7 +1908,8 @@
               "SubuserAPIDns",
               "SubuserCompute",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]

--- a/packages/openapi-client/specs/core.json
+++ b/packages/openapi-client/specs/core.json
@@ -90,6 +90,19 @@
               "nullable": true
             },
             "x-position": 3
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DnsViewType"
+                }
+              ]
+            },
+            "x-position": 4
           }
         ],
         "responses": {
@@ -166,6 +179,19 @@
               "format": "int64"
             },
             "x-position": 1
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DnsViewType"
+                }
+              ]
+            },
+            "x-position": 2
           }
         ],
         "responses": {
@@ -403,6 +429,106 @@
           },
           "400": {
             "description": "Failed adding the DNS record. Model validation failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request authorization failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "get": {
+        "tags": ["DNS Zone"],
+        "summary": "List DNS Zone Records",
+        "operationId": "DnsZonePublic_ListDnsZoneRecords",
+        "parameters": [
+          {
+            "name": "zoneId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the DNS Zone",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1,
+              "maximum": 2147483647.0,
+              "minimum": 1.0
+            },
+            "x-position": 2
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000.0,
+              "minimum": 5.0
+            },
+            "x-position": 3
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The type of DNS Record",
+            "schema": {
+              "oneOf": [
+                {
+                  "nullable": true,
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DnsRecordTypes2"
+                    }
+                  ]
+                }
+              ]
+            },
+            "x-position": 4
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of DNS records for the specified zone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginationListModelOfDnsRecordModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The DNS Zone with the requested ID does not exist"
+          },
+          "400": {
+            "description": "Failed to fetch dns records for the dns zone",
             "content": {
               "application/json": {
                 "schema": {
@@ -1249,6 +1375,16 @@
           },
           "500": {
             "description": "Internal Server Error"
+          },
+          "429": {
+            "description": "Too many certificate requests for this hostname; retry after the Retry-After interval",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
           }
         }
       }
@@ -1292,6 +1428,127 @@
           },
           "500": {
             "description": "Internal Server Error"
+          },
+          "429": {
+            "description": "Too many certificate requests for this hostname; retry after the Retry-After interval",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pullzone/requestExternalHttpCertificate": {
+      "post": {
+        "tags": ["Pull Zone"],
+        "summary": "Request External HTTP Certificate",
+        "operationId": "PullZonePublic_RequestExternalHttpCertificate",
+        "requestBody": {
+          "x-name": "req",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalHttpCertificateRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "The HTTP-01 challenge file details for verification",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "The request was invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The hostname was not found in the account"
+          },
+          "401": {
+            "description": "The request authorization failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "429": {
+            "description": "Too many certificate requests for this hostname; retry after the Retry-After interval",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pullzone/completeExternalHttpCertificate": {
+      "post": {
+        "tags": ["Pull Zone"],
+        "summary": "Complete External HTTP Certificate",
+        "operationId": "PullZonePublic_CompleteExternalHttpCertificate",
+        "requestBody": {
+          "x-name": "req",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalHttpCertificateRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "The certificate was successfully loaded"
+          },
+          "400": {
+            "description": "The verification failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The hostname was not found in the account"
+          },
+          "401": {
+            "description": "The request authorization failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "429": {
+            "description": "Too many certificate requests for this hostname; retry after the Retry-After interval",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
           }
         }
       }
@@ -2588,7 +2845,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -2598,7 +2856,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -2667,7 +2926,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -2677,7 +2937,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -2736,7 +2997,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -2746,7 +3008,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -2817,7 +3080,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -2827,7 +3091,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -2876,7 +3141,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -2886,7 +3152,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -2930,7 +3197,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -2940,7 +3208,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -2986,7 +3255,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -2996,7 +3266,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3071,7 +3342,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3081,7 +3353,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3154,7 +3427,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3164,7 +3438,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3283,7 +3558,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3293,7 +3569,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3362,7 +3639,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3372,7 +3650,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3418,7 +3697,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3428,7 +3708,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3474,7 +3755,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3484,7 +3766,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3559,7 +3842,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3569,7 +3853,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -3621,7 +3906,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3631,7 +3917,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ],
@@ -3676,7 +3963,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3686,7 +3974,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ],
@@ -3739,7 +4028,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3749,7 +4039,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ],
@@ -3794,7 +4085,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3804,7 +4096,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ],
@@ -3880,7 +4173,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           },
           {
@@ -3890,7 +4184,8 @@
               "SubuserAPIStream",
               "SubuserStream",
               "SubuserManage",
-              "SubuserAPIManage"
+              "SubuserAPIManage",
+              "ScopedApiKey"
             ]
           }
         ]
@@ -4086,6 +4381,114 @@
           },
           {
             "bearer": ["User", "UserApi", "Subuser"]
+          }
+        ]
+      }
+    },
+    "/storagezone/{id}/statistics/egress": {
+      "get": {
+        "tags": ["Storage Zone"],
+        "summary": "Get Storage Zone Egress Statistics",
+        "operationId": "GetStoragezoneEgressStatisticsEndpoint_StorageZoneEgressStatistics",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the storage zone",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "description": "(Optional) The start date of the statistics. If no value is passed, the last 30 days will be returned.",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "description": "(Optional) The end date of the statistics. If no value is passed, the last 30 days will be returned.",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "hourly",
+            "in": "query",
+            "description": "(Optional) If true, the statistics data will be returned in hourly groupping.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 4
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The egress statistics data for the passed parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StorageZoneEgressStatisticsModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The requested date range is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The StorageZone has not been found"
+          },
+          "401": {
+            "description": "The request authorization failed"
+          },
+          "403": {
+            "description": "The user does not have rights to access this resource"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "AccessKey": [
+              "User",
+              "UserApi",
+              "SubuserAPIStatistics",
+              "SubuserStatistics",
+              "SubuserManage",
+              "SubuserAPIManage"
+            ]
+          },
+          {
+            "bearer": [
+              "User",
+              "UserApi",
+              "SubuserAPIStatistics",
+              "SubuserStatistics",
+              "SubuserManage",
+              "SubuserAPIManage"
+            ]
           }
         ]
       }
@@ -4779,6 +5182,106 @@
         ]
       }
     },
+    "/v1/pricing/{source}/{resourceId}": {
+      "get": {
+        "tags": ["Pricing"],
+        "summary": "Get active price for a resource and optionally cost estimate if usage amount provided",
+        "operationId": "GetPriceEstimationEndpoint_GetPriceEstimation",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "required": true,
+            "description": "The billing source to estimate pricing for",
+            "schema": {
+              "$ref": "#/components/schemas/PricingEstimationSource"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the resource (pull zone, storage zone, video library, or edge script)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "units",
+            "in": "query",
+            "description": "Optional number of units to calculate estimated total cost",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The price estimation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PriceEstimationModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid pricing source or units",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The authenticated account does not have billing access"
+          },
+          "404": {
+            "description": "The resource was not found or is not accessible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorData"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "AccessKey": [
+              "User",
+              "UserApi",
+              "SubuserAPIBilling",
+              "SubuserBilling"
+            ]
+          },
+          {
+            "bearer": ["User", "UserApi", "SubuserAPIBilling", "SubuserBilling"]
+          }
+        ],
+        "x-hidden": true
+      }
+    },
     "/dnszone/{id}/statistics": {
       "get": {
         "tags": ["DNS Zone", "Statistics"],
@@ -5167,16 +5670,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
+          "404": {
+            "description": ""
           }
         },
         "security": [
@@ -5439,45 +5934,6 @@
   },
   "components": {
     "schemas": {
-      "BillingSummaryItem": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "PullZoneId": {
-            "type": "integer",
-            "description": "The ID of the pull zone",
-            "format": "int64"
-          },
-          "MonthlyUsage": {
-            "type": "number",
-            "description": "The total credit amount used in this month by the Pull Zone",
-            "format": "decimal"
-          },
-          "MonthlyBandwidthUsed": {
-            "type": "integer",
-            "description": "The total monthly bandwidth used by the pull zone",
-            "format": "int64"
-          }
-        }
-      },
-      "ApiErrorData": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "ErrorKey": {
-            "type": "string",
-            "nullable": true
-          },
-          "Field": {
-            "type": "string",
-            "nullable": true
-          },
-          "Message": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
       "CountryModel": {
         "type": "object",
         "additionalProperties": false,
@@ -5856,6 +6312,12 @@
         "x-enumNames": ["Ecdsa", "Rsa"],
         "enum": [0, 1]
       },
+      "DnsViewType": {
+        "type": "integer",
+        "description": "0 = Full\n1 = Lite",
+        "x-enumNames": ["Full", "Lite"],
+        "enum": [0, 1]
+      },
       "UpdateDnsZoneModel": {
         "type": "object",
         "additionalProperties": false,
@@ -5901,6 +6363,24 @@
           "LoggingIPAnonymizationEnabled": {
             "type": "boolean",
             "description": "Determines if the log anonoymization should be enabled",
+            "nullable": true
+          }
+        }
+      },
+      "ApiErrorData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "ErrorKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "Field": {
+            "type": "string",
+            "nullable": true
+          },
+          "Message": {
+            "type": "string",
             "nullable": true
           }
         }
@@ -6196,6 +6676,53 @@
           }
         }
       },
+      "PaginationListModelOfDnsRecordModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Items": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/DnsRecordModel"
+            }
+          },
+          "CurrentPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "TotalItems": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "HasMoreItems": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DnsRecordTypes2": {
+        "type": "integer",
+        "description": "0 = A\n1 = AAAA\n2 = CNAME\n3 = TXT\n4 = MX\n5 = Redirect\n6 = Flatten\n7 = PullZone\n8 = SRV\n9 = CAA\n10 = PTR\n11 = Script\n12 = NS\n13 = SVCB\n14 = HTTPS\n15 = TLSA",
+        "x-enumNames": [
+          "A",
+          "AAAA",
+          "CNAME",
+          "TXT",
+          "MX",
+          "Redirect",
+          "Flatten",
+          "PullZone",
+          "SRV",
+          "CAA",
+          "PTR",
+          "Script",
+          "NS",
+          "SVCB",
+          "HTTPS",
+          "TLSA"
+        ],
+        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+      },
       "PullZoneModel": {
         "type": "object",
         "additionalProperties": false,
@@ -6306,6 +6833,14 @@
           "EnableGeoZoneAF": {
             "type": "boolean",
             "description": "Determines if the delivery from the Africa region is enabled for this pull zone"
+          },
+          "IpFamilyPolicy": {
+            "description": "Address-family policy: 0=IPv4Only, 1=DualStack, 2=DualStackPreferIPv6, 3=IPv6Only.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/IpFamilyPolicy"
+              }
+            ]
           },
           "ZoneSecurityEnabled": {
             "type": "boolean",
@@ -7010,6 +7545,11 @@
           "EnableExtendedLogging": {
             "type": "boolean",
             "description": "Determines if extended logging with additional details is enabled for this Pull Zone."
+          },
+          "CacheKeyHeaders": {
+            "type": "string",
+            "description": "Vary Cache by Request Headers (comma delimited)",
+            "nullable": true
           }
         }
       },
@@ -7073,15 +7613,26 @@
       },
       "CertificateProvisionType": {
         "type": "integer",
-        "description": "0 = Unknown\n1 = Http01\n2 = Dns01\n3 = Custom",
-        "x-enumNames": ["Unknown", "Http01", "Dns01", "Custom"],
-        "enum": [0, 1, 2, 3]
+        "description": "0 = Unknown\n1 = Http01\n2 = Dns01\n3 = Custom\n4 = Managed",
+        "x-enumNames": ["Unknown", "Http01", "Dns01", "Custom", "Managed"],
+        "enum": [0, 1, 2, 3, 4]
       },
       "ExecutionPhase": {
         "type": "integer",
-        "description": "0 = Cache\n1 = LoadBalancer",
-        "x-enumNames": ["Cache", "LoadBalancer"],
-        "enum": [0, 1]
+        "description": "0 = Cache\n1 = LoadBalancer\n2 = PreCache",
+        "x-enumNames": ["Cache", "LoadBalancer", "PreCache"],
+        "enum": [0, 1, 2]
+      },
+      "IpFamilyPolicy": {
+        "type": "integer",
+        "description": "0 = IPv4Only\n1 = DualStack\n2 = DualStackPreferIPv6\n3 = IPv6Only",
+        "x-enumNames": [
+          "IPv4Only",
+          "DualStack",
+          "DualStackPreferIPv6",
+          "IPv6Only"
+        ],
+        "enum": [0, 1, 2, 3]
       },
       "PullZoneType": {
         "type": "integer",
@@ -7165,7 +7716,7 @@
       },
       "EdgeRuleActionType": {
         "type": "integer",
-        "description": "0 = ForceSSL\n1 = Redirect\n2 = OriginUrl\n3 = OverrideCacheTime\n4 = BlockRequest\n5 = SetResponseHeader\n6 = SetRequestHeader\n7 = ForceDownload\n8 = DisableTokenAuthentication\n9 = EnableTokenAuthentication\n10 = OverrideCacheTimePublic\n11 = IgnoreQueryString\n12 = DisableOptimizer\n13 = ForceCompression\n14 = SetStatusCode\n15 = BypassPermaCache\n16 = OverrideBrowserCacheTime\n17 = OriginStorage\n18 = SetNetworkRateLimit\n19 = SetConnectionLimit\n20 = SetRequestsPerSecondLimit\n21 = RunEdgeScript\n22 = OriginMagicContainers\n23 = DisableWAF\n24 = RetryOrigin\n25 = OverrideBrowserCacheResponseHeader\n26 = RemoveBrowserCacheResponseHeader\n27 = DisableShieldChallenge\n28 = DisableShield\n29 = DisableShieldBotDetection\n30 = BypassAwsS3Authentication\n31 = DisableShieldAccessLists\n32 = DisableShieldRateLimiting\n33 = EnableRequestCoalescing\n34 = DisableRequestCoalescing",
+        "description": "0 = ForceSSL\n1 = Redirect\n2 = OriginUrl\n3 = OverrideCacheTime\n4 = BlockRequest\n5 = SetResponseHeader\n6 = SetRequestHeader\n7 = ForceDownload\n8 = DisableTokenAuthentication\n9 = EnableTokenAuthentication\n10 = OverrideCacheTimePublic\n11 = IgnoreQueryString\n12 = DisableOptimizer\n13 = ForceCompression\n14 = SetStatusCode\n15 = BypassPermaCache\n16 = OverrideBrowserCacheTime\n17 = OriginStorage\n18 = SetNetworkRateLimit\n19 = SetConnectionLimit\n20 = SetRequestsPerSecondLimit\n21 = RunEdgeScript\n22 = OriginMagicContainers\n23 = DisableWAF\n24 = RetryOrigin\n25 = OverrideBrowserCacheResponseHeader\n26 = RemoveBrowserCacheResponseHeader\n27 = DisableShieldChallenge\n28 = DisableShield\n29 = DisableShieldBotDetection\n30 = BypassAwsS3Authentication\n31 = DisableShieldAccessLists\n32 = DisableShieldRateLimiting\n33 = EnableRequestCoalescing\n34 = DisableRequestCoalescing\n37 = StripCookiesClientToOrigin",
         "x-enumNames": [
           "ForceSSL",
           "Redirect",
@@ -7201,11 +7752,12 @@
           "DisableShieldAccessLists",
           "DisableShieldRateLimiting",
           "EnableRequestCoalescing",
-          "DisableRequestCoalescing"
+          "DisableRequestCoalescing",
+          "StripCookiesClientToOrigin"
         ],
         "enum": [
           0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-          20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34
+          20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 37
         ]
       },
       "Trigger": {
@@ -7479,6 +8031,15 @@
             "description": "Determines if the delivery from the Africa region should be enabled for this pull zone",
             "nullable": true
           },
+          "IpFamilyPolicy": {
+            "description": "Address-family policy: 0=IPv4Only, 1=DualStack (default, best latency and compatibility), 2=DualStackPreferIPv6, 3=IPv6Only.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/IpFamilyPolicy"
+              }
+            ]
+          },
           "BlockRootPathAccess": {
             "type": "boolean",
             "description": "Determines if the zone should block requests to the root of the zone.",
@@ -8252,6 +8813,11 @@
             "description": "The maximum global simultaneous WebSocket connections allowed for this Pull Zone. Allowed tiers: 500, 1,000, 2,500, 5,000, 10,000, 25,000. If you send a non-tier value, the value is rounded up to the next tier. Values over 25,000 are rejected, please contact sales if required.",
             "format": "int32",
             "nullable": true
+          },
+          "CacheKeyHeaders": {
+            "type": "string",
+            "description": "Vary Cache by Request Headers (comma delimited)",
+            "nullable": true
           }
         }
       },
@@ -8289,6 +8855,17 @@
         }
       },
       "ExternalDnsCertificateRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["Hostname"],
+        "properties": {
+          "Hostname": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "ExternalHttpCertificateRequest": {
         "type": "object",
         "additionalProperties": false,
         "required": ["Hostname"],
@@ -8372,6 +8949,15 @@
             "description": "Determines if the delivery from the Africa region should be enabled for this pull zone",
             "nullable": true
           },
+          "IpFamilyPolicy": {
+            "description": "Address-family policy: 0=IPv4Only, 1=DualStack (default, best latency and compatibility), 2=DualStackPreferIPv6, 3=IPv6Only.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/IpFamilyPolicy"
+              }
+            ]
+          },
           "BlockRootPathAccess": {
             "type": "boolean",
             "description": "Determines if the zone should block requests to the root of the zone.",
@@ -9144,6 +9730,11 @@
             "type": "integer",
             "description": "The maximum global simultaneous WebSocket connections allowed for this Pull Zone. Allowed tiers: 500, 1,000, 2,500, 5,000, 10,000, 25,000. If you send a non-tier value, the value is rounded up to the next tier. Values over 25,000 are rejected, please contact sales if required.",
             "format": "int32",
+            "nullable": true
+          },
+          "CacheKeyHeaders": {
+            "type": "string",
+            "description": "Vary Cache by Request Headers (comma delimited)",
             "nullable": true
           },
           "Name": {
@@ -9418,6 +10009,11 @@
           "StorageHostname": {
             "type": "string",
             "description": "Determines the storage hostname for this zone",
+            "nullable": true
+          },
+          "S3Hostname": {
+            "type": "string",
+            "description": "Determines the S3 compatible hostname for this zone",
             "nullable": true
           },
           "ZoneTier": {
@@ -10699,6 +11295,96 @@
         "x-enumNames": ["Ascending", "Descending"],
         "enum": ["Ascending", "Descending"]
       },
+      "StorageZoneEgressStatisticsModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "HttpEgressChart": {
+            "type": "object",
+            "description": "Download traffic served over HTTP",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "S3EgressChart": {
+            "type": "object",
+            "description": "Download traffic served over S3",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "S3PresignedEgressChart": {
+            "type": "object",
+            "description": "Download traffic served over presigned S3 URLs",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "FtpEgressChart": {
+            "type": "object",
+            "description": "Download traffic served over FTP",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "SftpEgressChart": {
+            "type": "object",
+            "description": "Download traffic served over SFTP",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "TotalEgressChart": {
+            "type": "object",
+            "description": "Total download traffic across all protocols",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "HttpEgressTotal": {
+            "type": "integer",
+            "description": "Total download traffic over HTTP",
+            "format": "int64"
+          },
+          "S3EgressTotal": {
+            "type": "integer",
+            "description": "Total download traffic over S3",
+            "format": "int64"
+          },
+          "S3PresignedEgressTotal": {
+            "type": "integer",
+            "description": "Total download traffic over presigned S3 URLs",
+            "format": "int64"
+          },
+          "FtpEgressTotal": {
+            "type": "integer",
+            "description": "Total download traffic over FTP",
+            "format": "int64"
+          },
+          "SftpEgressTotal": {
+            "type": "integer",
+            "description": "Total download traffic over SFTP",
+            "format": "int64"
+          },
+          "TotalEgress": {
+            "type": "integer",
+            "description": "Total download traffic across all protocols",
+            "format": "int64"
+          }
+        }
+      },
       "StorageRegionModel": {
         "type": "object",
         "additionalProperties": false,
@@ -11088,6 +11774,125 @@
           }
         }
       },
+      "PriceEstimationModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "PricingType": {
+            "$ref": "#/components/schemas/AppliedPricingType"
+          },
+          "PricePerUnit": {
+            "type": "number",
+            "format": "decimal"
+          },
+          "UnitDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "EstimatedCost": {
+            "type": "number",
+            "format": "decimal",
+            "nullable": true
+          },
+          "Breakdown": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/PriceEstimationBreakdownLine"
+            }
+          }
+        }
+      },
+      "AppliedPricingType": {
+        "type": "integer",
+        "description": "0 = ListPrice\n1 = UserOverride\n2 = ResourceOverride",
+        "x-enumNames": ["ListPrice", "UserOverride", "ResourceOverride"],
+        "enum": [0, 1, 2]
+      },
+      "PriceEstimationBreakdownLine": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Units": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "PricePerUnit": {
+            "type": "number",
+            "format": "decimal"
+          },
+          "Cost": {
+            "type": "number",
+            "format": "decimal"
+          }
+        }
+      },
+      "PricingEstimationSource": {
+        "type": "integer",
+        "description": "1101 = CDN_Standard_Tier_EU_Traffic\n1102 = CDN_Standard_Tier_NA_Traffic\n1103 = CDN_Standard_Tier_APAC_Traffic\n1104 = CDN_Standard_Tier_AF_Traffic\n1105 = CDN_Standard_Tier_SA_Traffic\n1106 = CDN_Standard_Tier_Uncategorized\n1201 = CDN_Standard_Tier_Stream_EU_Traffic\n1202 = CDN_Standard_Tier_Stream_NA_Traffic\n1203 = CDN_Standard_Tier_Stream_APAC_Traffic\n1204 = CDN_Standard_Tier_Stream_AF_Traffic\n1205 = CDN_Standard_Tier_Stream_SA_Traffic\n1206 = CDN_Standard_Tier_Stream_Uncategorized\n1300 = CDN_Volume_Tier\n1400 = CDN_Volume_Tier_Stream\n1501 = CDN_Standard_Tier_Storage_EU_Traffic\n1502 = CDN_Standard_Tier_Storage_NA_Traffic\n1503 = CDN_Standard_Tier_Storage_APAC_Traffic\n1504 = CDN_Standard_Tier_Storage_AF_Traffic\n1505 = CDN_Standard_Tier_Storage_SA_Traffic\n1506 = CDN_Standard_Tier_Storage_Uncategorized\n1510 = CDN_Volume_Tier_Storage\n1630 = CDN_WebSockets_ConsumptionBased\n1701 = CDN_Standard_Tier_MagicContainers_EU_Traffic\n1702 = CDN_Standard_Tier_MagicContainers_NA_Traffic\n1703 = CDN_Standard_Tier_MagicContainers_APAC_Traffic\n1704 = CDN_Standard_Tier_MagicContainers_AF_Traffic\n1705 = CDN_Standard_Tier_MagicContainers_SA_Traffic\n1706 = CDN_Standard_Tier_MagicContainers_Uncategorized\n1710 = CDN_Volume_Tier_MagicContainers\n1801 = CDN_Standard_Tier_Scripting_EU_Traffic\n1802 = CDN_Standard_Tier_Scripting_NA_Traffic\n1803 = CDN_Standard_Tier_Scripting_APAC_Traffic\n1804 = CDN_Standard_Tier_Scripting_AF_Traffic\n1805 = CDN_Standard_Tier_Scripting_SA_Traffic\n1806 = CDN_Standard_Tier_Scripting_Uncategorized\n1810 = CDN_Volume_Tier_Scripting\n2100 = Storage_Standard_Tier\n2200 = Storage_SSD_Tier\n2300 = Storage_Standard_Tier_Stream\n2400 = Storage_SSD_Tier_Stream\n4100 = Transcribing\n4200 = PremiumEncoding\n4300 = DRM_Base\n4400 = DRM_LicenseIssued\n4501 = LiveEncoding_SD\n4502 = LiveEncoding_HD\n4503 = LiveEncoding_4K\n5200 = Scripting_CDN_Requests\n5300 = Scripting_CDN_CPU",
+        "x-enumNames": [
+          "CDN_Standard_Tier_EU_Traffic",
+          "CDN_Standard_Tier_NA_Traffic",
+          "CDN_Standard_Tier_APAC_Traffic",
+          "CDN_Standard_Tier_AF_Traffic",
+          "CDN_Standard_Tier_SA_Traffic",
+          "CDN_Standard_Tier_Uncategorized",
+          "CDN_Standard_Tier_Stream_EU_Traffic",
+          "CDN_Standard_Tier_Stream_NA_Traffic",
+          "CDN_Standard_Tier_Stream_APAC_Traffic",
+          "CDN_Standard_Tier_Stream_AF_Traffic",
+          "CDN_Standard_Tier_Stream_SA_Traffic",
+          "CDN_Standard_Tier_Stream_Uncategorized",
+          "CDN_Volume_Tier",
+          "CDN_Volume_Tier_Stream",
+          "CDN_Standard_Tier_Storage_EU_Traffic",
+          "CDN_Standard_Tier_Storage_NA_Traffic",
+          "CDN_Standard_Tier_Storage_APAC_Traffic",
+          "CDN_Standard_Tier_Storage_AF_Traffic",
+          "CDN_Standard_Tier_Storage_SA_Traffic",
+          "CDN_Standard_Tier_Storage_Uncategorized",
+          "CDN_Volume_Tier_Storage",
+          "CDN_WebSockets_ConsumptionBased",
+          "CDN_Standard_Tier_MagicContainers_EU_Traffic",
+          "CDN_Standard_Tier_MagicContainers_NA_Traffic",
+          "CDN_Standard_Tier_MagicContainers_APAC_Traffic",
+          "CDN_Standard_Tier_MagicContainers_AF_Traffic",
+          "CDN_Standard_Tier_MagicContainers_SA_Traffic",
+          "CDN_Standard_Tier_MagicContainers_Uncategorized",
+          "CDN_Volume_Tier_MagicContainers",
+          "CDN_Standard_Tier_Scripting_EU_Traffic",
+          "CDN_Standard_Tier_Scripting_NA_Traffic",
+          "CDN_Standard_Tier_Scripting_APAC_Traffic",
+          "CDN_Standard_Tier_Scripting_AF_Traffic",
+          "CDN_Standard_Tier_Scripting_SA_Traffic",
+          "CDN_Standard_Tier_Scripting_Uncategorized",
+          "CDN_Volume_Tier_Scripting",
+          "Storage_Standard_Tier",
+          "Storage_SSD_Tier",
+          "Storage_Standard_Tier_Stream",
+          "Storage_SSD_Tier_Stream",
+          "Transcribing",
+          "PremiumEncoding",
+          "DRM_Base",
+          "DRM_LicenseIssued",
+          "LiveEncoding_SD",
+          "LiveEncoding_HD",
+          "LiveEncoding_4K",
+          "Scripting_CDN_Requests",
+          "Scripting_CDN_CPU"
+        ],
+        "enum": [
+          1101, 1102, 1103, 1104, 1105, 1106, 1201, 1202, 1203, 1204, 1205,
+          1206, 1300, 1400, 1501, 1502, 1503, 1504, 1505, 1506, 1510, 1630,
+          1701, 1702, 1703, 1704, 1705, 1706, 1710, 1801, 1802, 1803, 1804,
+          1805, 1806, 1810, 2100, 2200, 2300, 2400, 4100, 4200, 4300, 4400,
+          4501, 4502, 4503, 5200, 5300
+        ]
+      },
       "DnsZoneRecordScanJobResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -11336,6 +12141,21 @@
             "type": "number",
             "description": "Last recharge amount balance",
             "format": "double"
+          },
+          "AvailableBalance": {
+            "type": "number",
+            "description": "The current account balance plus available (unexpired) coupon credit",
+            "format": "double"
+          },
+          "CouponBalance": {
+            "type": "number",
+            "description": "All available (unexpired) coupon money on the account",
+            "format": "decimal"
+          },
+          "MonthlyCouponUsage": {
+            "type": "number",
+            "description": "The total coupon credit used this month across all services",
+            "format": "decimal"
           },
           "BillingRecords": {
             "type": "array",
@@ -11868,6 +12688,27 @@
           }
         }
       },
+      "BillingSummaryItem": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "PullZoneId": {
+            "type": "integer",
+            "description": "The ID of the pull zone",
+            "format": "int64"
+          },
+          "MonthlyUsage": {
+            "type": "number",
+            "description": "The total credit amount used in this month by the Pull Zone",
+            "format": "decimal"
+          },
+          "MonthlyBandwidthUsed": {
+            "type": "integer",
+            "description": "The total monthly bandwidth used by the pull zone",
+            "format": "int64"
+          }
+        }
+      },
       "PaginationListModelOfApiKeyModel": {
         "type": "object",
         "additionalProperties": false,
@@ -12003,6 +12844,9 @@
     },
     {
       "name": "Pull Zone"
+    },
+    {
+      "name": "Pricing"
     },
     {
       "name": "DNS Zone"

--- a/packages/openapi-client/specs/magic-containers.json
+++ b/packages/openapi-client/specs/magic-containers.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.4",
   "info": {
     "title": "Public API",
-    "description": "Public API endpoints for user consumption. Release version: v1.9.22.0",
+    "description": "Public API endpoints for user consumption. Release version: v1.10.2.0",
     "version": "1.0"
   },
   "servers": [
@@ -1586,6 +1586,65 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/registries/image-config": {
+      "post": {
+        "tags": ["ContainerRegistries"],
+        "summary": "Get Image Config",
+        "description": "Retrieves endpoint and volume suggestions for a container image from a registry.",
+        "operationId": "GetImageConfig",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListContainerImageExposedPortsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListContainerImageExposedPortsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListContainerImageExposedPortsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Image configuration was successfully retrieved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageConfig"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User is unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -3486,6 +3545,7 @@
         "tags": ["Log Forwarding"],
         "summary": "List log-forwarding configurations",
         "description": "Get a list of all log-forwarding configurations for the authenticated user.",
+        "operationId": "ListLogForwardingConfigurations",
         "responses": {
           "200": {
             "description": "List of log-forwarding configurations retrieved successfully.",
@@ -3509,6 +3569,7 @@
         "tags": ["Log Forwarding"],
         "summary": "Create log forwarding configuration",
         "description": "Create a new log forwarding configuration.",
+        "operationId": "CreateLogForwardingConfiguration",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3547,6 +3608,7 @@
         "tags": ["Log Forwarding"],
         "summary": "Get log-forwarding configuration",
         "description": "Get a specific log-forwarding configuration by ID.",
+        "operationId": "GetLogForwardingConfiguration",
         "parameters": [
           {
             "name": "appId",
@@ -3584,6 +3646,7 @@
         "tags": ["Log Forwarding"],
         "summary": "Update log-forwarding configuration",
         "description": "Update an existing log-forwarding configuration.",
+        "operationId": "UpdateLogForwardingConfiguration",
         "parameters": [
           {
             "name": "appId",
@@ -3634,6 +3697,7 @@
         "tags": ["Log Forwarding"],
         "summary": "Delete log-forwarding configuration",
         "description": "Delete a log-forwarding configuration.",
+        "operationId": "DeleteLogForwardingConfiguration",
         "parameters": [
           {
             "name": "appId",
@@ -3808,7 +3872,7 @@
         "additionalProperties": false
       },
       "AnycastIpProtocolVersion": {
-        "enum": ["ipv4"],
+        "enum": ["iPv4"],
         "type": "string"
       },
       "AppListItem": {
@@ -3973,6 +4037,12 @@
               "$ref": "#/components/schemas/EnvironmentVariableSuggestion"
             }
           },
+          "volumeSuggestions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VolumeSuggestion"
+            }
+          },
           "appName": {
             "type": "string",
             "nullable": true
@@ -3995,6 +4065,7 @@
       "ContainerEndpoint": {
         "required": [
           "displayName",
+          "id",
           "isSslEnabled",
           "portMappings",
           "publicHost",
@@ -4003,6 +4074,11 @@
         ],
         "type": "object",
         "properties": {
+          "id": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Unique endpoint id. Use this value as `container_endpoint_id` when creating a pull zone that targets this endpoint."
+          },
           "displayName": {
             "minLength": 1,
             "type": "string"
@@ -4265,6 +4341,9 @@
             "type": "boolean",
             "nullable": true
           },
+          "isPlatformManaged": {
+            "type": "boolean"
+          },
           "lastUpdatedAt": {
             "type": "string",
             "format": "date-time",
@@ -4278,6 +4357,7 @@
         "type": "object",
         "properties": {
           "displayName": {
+            "maxLength": 50,
             "minLength": 1,
             "type": "string",
             "description": "Container registry display name"
@@ -5014,6 +5094,24 @@
         ],
         "type": "string"
       },
+      "ImageConfig": {
+        "type": "object",
+        "properties": {
+          "endpointSuggestions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EndpointRequest"
+            }
+          },
+          "volumeSuggestions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VolumeSuggestion"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "ImagePullPolicy": {
         "enum": ["always", "ifNotPresent"],
         "type": "string"
@@ -5069,6 +5167,33 @@
         },
         "additionalProperties": false,
         "description": "List applications response"
+      },
+      "ListContainerImageExposedPortsRequest": {
+        "required": ["imageName", "imageNamespace", "registryId", "tag"],
+        "type": "object",
+        "properties": {
+          "registryId": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The registry identifier. Can be \"dockerhub\", \"github\", or a private registry ID."
+          },
+          "imageName": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          "imageNamespace": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          "tag": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "ListContainerImageTagsRequest": {
         "required": ["imageName", "imageNamespace", "registryId"],
@@ -5484,6 +5609,16 @@
             "type": "number",
             "format": "double",
             "nullable": true
+          },
+          "outboundConnectionsLimit": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "outboundConnectionsRejectedDiff": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -5762,7 +5897,7 @@
         "description": "Region settings model"
       },
       "RegistryType": {
-        "enum": ["dockerHub", "gitHub"],
+        "enum": ["dockerHub", "gitHub", "bunnyRegistry"],
         "type": "string"
       },
       "RemoveContainerRegistryResponseStatus": {
@@ -6208,6 +6343,9 @@
           "usage": {
             "type": "number",
             "format": "double"
+          },
+          "set": {
+            "type": "string"
           }
         },
         "additionalProperties": false,
@@ -6259,9 +6397,22 @@
           "creating",
           "notScheduled",
           "scheduled",
-          "failed"
+          "failed",
+          "maintenance"
         ],
         "type": "string"
+      },
+      "VolumeSuggestion": {
+        "type": "object",
+        "properties": {
+          "containerPath": {
+            "type": "string"
+          },
+          "suggestedVolumeName": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "VolumeTemplate": {
         "required": ["name", "size"],

--- a/packages/openapi-client/specs/origin-errors.json
+++ b/packages/openapi-client/specs/origin-errors.json
@@ -15,9 +15,7 @@
             "name": "pullZoneId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "integer"
-            },
+            "schema": { "type": "integer" },
             "description": "The ID of the Pull Zone."
           },
           {
@@ -32,28 +30,17 @@
             "description": "The date for which to retrieve logs, formatted as MM-dd-yyyy."
           }
         ],
-        "security": [
-          {
-            "AccessKeyAuth": []
-          },
-          {
-            "JWTAuth": []
-          }
-        ],
+        "security": [{ "AccessKeyAuth": [] }, { "JWTAuth": [] }],
         "responses": {
           "200": {
             "description": "Successful response with log data",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LogResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/LogResponse" }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized - missing or invalid API key"
-          }
+          "401": { "description": "Unauthorized - missing or invalid API key" }
         }
       }
     }
@@ -79,9 +66,7 @@
         "properties": {
           "logs": {
             "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LogEntry"
-            }
+            "items": { "$ref": "#/components/schemas/LogEntry" }
           }
         }
       },
@@ -93,10 +78,7 @@
             "format": "uuid",
             "example": "a6a6b755-b6a4-46be-b523-aa82a17d4bc5"
           },
-          "timestamp": {
-            "type": "integer",
-            "example": 1728952065848
-          },
+          "timestamp": { "type": "integer", "example": 1728952065848 },
           "log": {
             "type": "string",
             "example": "{\"RequestUrl\":\"/apikey\",\"PullZoneId\":308006,\"Message\":\"Origin DNS lookup failed...\",\"ErrorCode\":\"dns_lookup\",\"StatusCode\":502}"
@@ -104,27 +86,14 @@
           "labels": {
             "type": "object",
             "properties": {
-              "ErrorCode": {
-                "type": "string",
-                "example": "dns_lookup"
-              },
-              "StatusCode": {
-                "type": "string",
-                "example": "502"
-              },
-              "ServerZone": {
-                "type": "string",
-                "example": "CA"
-              }
+              "ErrorCode": { "type": "string", "example": "dns_lookup" },
+              "StatusCode": { "type": "string", "example": "502" },
+              "ServerZone": { "type": "string", "example": "CA" }
             }
           }
         }
       }
     }
   },
-  "servers": [
-    {
-      "url": "https://cdn-origin-logging.bunny.net"
-    }
-  ]
+  "servers": [{ "url": "https://cdn-origin-logging.bunny.net" }]
 }

--- a/packages/openapi-client/specs/shield.json
+++ b/packages/openapi-client/specs/shield.json
@@ -1416,6 +1416,413 @@
         }
       }
     },
+    "/shield/shield-zone/{shieldZoneId}/bot-categorization": {
+      "get": {
+        "tags": ["Bot Categorization"],
+        "summary": "List bots available for explicit allow/block configuration on this Shield Zone, grouped by category.",
+        "operationId": "List Bot Categorizations",
+        "parameters": [
+          {
+            "name": "shieldZoneId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCategorizationListResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/shield/shield-zone/{shieldZoneId}/bot-categorization/bots/{botId}": {
+      "put": {
+        "tags": ["Bot Categorization"],
+        "summary": "Set or clear the action applied to a categorised bot for this Shield Zone.",
+        "operationId": "Set Bot Categorization Action",
+        "parameters": [
+          {
+            "name": "shieldZoneId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "botId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategorizationConfigurationResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/shield/shield-zone/{shieldZoneId}/bot-categorization/categories/{category}": {
+      "put": {
+        "tags": ["Bot Categorization"],
+        "summary": "Set or clear the action applied to every bot in a category for this Shield Zone.",
+        "operationId": "Set Bot Category Action",
+        "parameters": [
+          {
+            "name": "shieldZoneId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "category",
+            "in": "path",
+            "description": "0 = None\n1 = SEO\n2 = AIScraper\n3 = AITool\n4 = Tool\n5 = Ads\n6 = Preview\n7 = Social\n255 = System",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/BotCategory"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBotCategoryConfigurationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBotCategoryConfigurationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBotCategoryConfigurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBotCategoryConfigurationResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/shield/shield-zone/{shieldZoneId}/bot-detection": {
       "get": {
         "tags": ["Bot Detection"],
@@ -2106,6 +2513,306 @@
         }
       }
     },
+    "/shield/event-logs/{shieldZoneId}/search": {
+      "post": {
+        "tags": ["Event Logs"],
+        "summary": "Search, filter and group Event Logs for a Shield Zone",
+        "operationId": "Search Event Logs",
+        "parameters": [
+          {
+            "name": "shieldZoneId",
+            "in": "path",
+            "description": "The ID of the Shield Zone.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "The ID of the Shield Zone.",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventLogsSearchRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventLogsSearchRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventLogsSearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventLogsSearchResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventLogsSearchResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventLogsSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/shield/event-logs/{shieldZoneId}/export": {
+      "post": {
+        "tags": ["Event Logs"],
+        "summary": "Export the full filtered Event Logs set for a Shield Zone as CSV",
+        "operationId": "Export Event Logs",
+        "parameters": [
+          {
+            "name": "shieldZoneId",
+            "in": "path",
+            "description": "The ID of the Shield Zone.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "The ID of the Shield Zone.",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventLogsExportRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventLogsExportRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventLogsExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/shield/metrics/overages/{shieldZoneId}": {
+      "get": {
+        "tags": ["Metrics"],
+        "summary": "Get the overage breakdown for the specified Shield Zone for a given month, segmented by billing plan changes",
+        "operationId": "Get Shield Zone Monthly Overages",
+        "parameters": [
+          {
+            "name": "shieldZoneId",
+            "in": "path",
+            "description": "The ID of the Shield Zone.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "The ID of the Shield Zone.",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "The calendar year to query.",
+            "schema": {
+              "type": "integer",
+              "description": "The calendar year to query.",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "The calendar month (1-12) to query.",
+            "schema": {
+              "type": "integer",
+              "description": "The calendar month (1-12) to query.",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShieldZoneMonthlyOveragesResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShieldZoneMonthlyOveragesResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShieldZoneMonthlyOveragesResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/shield/metrics/overview/{shieldZoneId}": {
       "get": {
         "tags": ["Metrics"],
@@ -2207,6 +2914,7 @@
           {
             "name": "Resolution",
             "in": "query",
+            "description": "0 = Auto\n1 = TwoMinutes\n2 = TenMinutes\n3 = Hourly\n4 = Daily\n5 = Weekly\n6 = Monthly",
             "schema": {
               "$ref": "#/components/schemas/MetricsOverviewResolution"
             }
@@ -3476,6 +4184,170 @@
         }
       }
     },
+    "/shield/shield-zone/defaults": {
+      "get": {
+        "tags": ["Shield Zone"],
+        "summary": "Get the recommended defaults for creating a Shield Zone",
+        "operationId": "Get Shield Zone Defaults",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetShieldZoneDefaultsResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetShieldZoneDefaultsResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetShieldZoneDefaultsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/shield/shield-zone/under-attack": {
+      "post": {
+        "tags": ["Shield Zone"],
+        "summary": "Create a Shield Zone in under-attack mode for your PullZone",
+        "operationId": "Create Shield Zone Under Attack",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUnderAttackShieldZoneRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUnderAttackShieldZoneRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUnderAttackShieldZoneRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/shield/shield-zone": {
       "post": {
         "tags": ["Shield Zone"],
@@ -3504,6 +4376,26 @@
         "responses": {
           "200": {
             "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShieldZoneResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": {
               "text/plain": {
                 "schema": {
@@ -5004,14 +5896,41 @@
       "AccessListAction": {
         "enum": [0, 1, 2, 3, 4, 5],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = None\n1 = Allow\n2 = Block\n3 = Challenge\n4 = Log\n5 = Bypass",
+        "format": "int32",
+        "x-enum-varnames": [
+          "None",
+          "Allow",
+          "Block",
+          "Challenge",
+          "Log",
+          "Bypass"
+        ]
       },
       "AccessListCategory": {
         "enum": [
           0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
         ],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = None\n1 = VPNs\n2 = Datacenters\n4 = Proxies\n8 = TorExitNodes\n16 = Botnets\n32 = VulnerabilityScanners\n64 = WebScrapers\n128 = SearchEngines\n256 = SearchEngineCrawlers\n512 = AiSearch\n1024 = AiCrawlers\n2048 = AiAgents\n4096 = PagePreview\n8192 = InternetTools",
+        "format": "int32",
+        "x-enum-varnames": [
+          "None",
+          "VPNs",
+          "Datacenters",
+          "Proxies",
+          "TorExitNodes",
+          "Botnets",
+          "VulnerabilityScanners",
+          "WebScrapers",
+          "SearchEngines",
+          "SearchEngineCrawlers",
+          "AiSearch",
+          "AiCrawlers",
+          "AiAgents",
+          "PagePreview",
+          "InternetTools"
+        ]
       },
       "AccessListDetails": {
         "required": [
@@ -5085,7 +6004,16 @@
       "AccessListType": {
         "enum": [0, 1, 2, 3, 4, 5],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = IP\n1 = CIDR\n2 = ASN\n3 = Country\n4 = Organization\n5 = JA4",
+        "format": "int32",
+        "x-enum-varnames": [
+          "IP",
+          "CIDR",
+          "ASN",
+          "Country",
+          "Organization",
+          "JA4"
+        ]
       },
       "AccessListsDetailsResponse": {
         "type": "object",
@@ -5487,15 +6415,13 @@
         "additionalProperties": false
       },
       "ApiGuardianRateLimitType": {
-        "enum": [0, 1],
-        "type": "integer",
-        "format": "int32"
+        "enum": ["Global", "IP"],
+        "type": "string"
       },
       "AuthLocation": {
-        "enum": [0, 1, 2],
-        "type": "integer",
-        "description": "Where an authentication credential is transmitted in the HTTP request.",
-        "format": "int32"
+        "enum": ["Header", "Query", "Cookie"],
+        "type": "string",
+        "description": "Where an authentication credential is transmitted in the HTTP request."
       },
       "AuthSchemeDetails": {
         "type": "object",
@@ -5526,10 +6452,119 @@
         "description": "Describes a single authentication scheme required by an endpoint,\nas extracted from the OpenAPI specification's securitySchemes."
       },
       "AuthSchemeType": {
+        "enum": ["ApiKey", "Http", "OAuth2", "OpenIdConnect"],
+        "type": "string",
+        "description": "The type of security scheme as defined in the OpenAPI specification."
+      },
+      "BotCategorizationAction": {
         "enum": [0, 1, 2, 3],
         "type": "integer",
-        "description": "The type of security scheme as defined in the OpenAPI specification.",
-        "format": "int32"
+        "description": "0 = None\n1 = Block\n2 = Allow\n3 = Ignore",
+        "format": "int32",
+        "x-enum-varnames": ["None", "Block", "Allow", "Ignore"]
+      },
+      "BotCategorizationDetails": {
+        "required": [
+          "action",
+          "botId",
+          "category",
+          "isVerifiable",
+          "userAgentMatch"
+        ],
+        "type": "object",
+        "properties": {
+          "botId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "userAgentMatch": {
+            "type": "string",
+            "nullable": true
+          },
+          "category": {
+            "$ref": "#/components/schemas/BotCategory"
+          },
+          "action": {
+            "$ref": "#/components/schemas/BotCategorizationAction"
+          },
+          "isVerifiable": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BotCategorizationGroup": {
+        "required": ["bots", "category", "categoryAction"],
+        "type": "object",
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/BotCategory"
+          },
+          "categoryAction": {
+            "$ref": "#/components/schemas/BotCategoryAction"
+          },
+          "bots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BotCategorizationDetails"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BotCategorizationListResponse": {
+        "type": "object",
+        "properties": {
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BotCategorizationGroup"
+            },
+            "nullable": true
+          },
+          "error": {
+            "$ref": "#/components/schemas/GenericRequestResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BotCategory": {
+        "enum": [0, 1, 2, 3, 4, 5, 6, 7],
+        "type": "integer",
+        "description": "0 = None\n1 = SEO\n2 = AIScraper\n3 = AITool\n4 = Tool\n5 = Ads\n6 = Preview\n7 = Social\n255 = System",
+        "format": "int32",
+        "x-enum-varnames": [
+          "None",
+          "SEO",
+          "AIScraper",
+          "AITool",
+          "Tool",
+          "Ads",
+          "Preview",
+          "Social",
+          "System"
+        ]
+      },
+      "BotCategoryAction": {
+        "enum": [0, 1, 2],
+        "type": "integer",
+        "description": "0 = None\n1 = Block\n2 = Allow",
+        "format": "int32",
+        "x-enum-varnames": ["None", "Block", "Allow"]
+      },
+      "BotCategoryDetails": {
+        "required": ["action", "category"],
+        "type": "object",
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/BotCategory"
+          },
+          "action": {
+            "$ref": "#/components/schemas/BotCategoryAction"
+          }
+        },
+        "additionalProperties": false
       },
       "BotDetectionConfigurationResponse": {
         "type": "object",
@@ -5583,17 +6618,23 @@
       "BotDetectionExecutionMode": {
         "enum": [0, 1],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = LogOnly\n1 = Challenge",
+        "format": "int32",
+        "x-enum-varnames": ["LogOnly", "Challenge"]
       },
       "BotDetectionSensitivity": {
         "enum": [0, 1, 2, 3],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Off\n1 = Low\n2 = Medium\n3 = High",
+        "format": "int32",
+        "x-enum-varnames": ["Off", "Low", "Medium", "High"]
       },
       "BrowserFingerprintAggression": {
         "enum": [0, 1, 2, 3, 4],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Unknown\n1 = Low\n2 = Medium\n3 = High\n4 = Custom",
+        "format": "int32",
+        "x-enum-varnames": ["Unknown", "Low", "Medium", "High", "Custom"]
       },
       "BrowserFingerprintConfiguration": {
         "type": "object",
@@ -5767,6 +6808,14 @@
             "type": "string",
             "nullable": true
           },
+          "isNegated": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "isRegexVariable": {
+            "type": "boolean",
+            "nullable": true
+          },
           "chainedRuleConditions": {
             "type": "array",
             "items": {
@@ -5808,6 +6857,22 @@
           "pullZoneId": {
             "type": "integer",
             "format": "int64"
+          },
+          "accessLists": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AccessListAction"
+            },
+            "nullable": true
+          },
+          "botDetectionExecutionMode": {
+            "$ref": "#/components/schemas/BotDetectionExecutionMode"
+          },
+          "csamScanningMode": {
+            "$ref": "#/components/schemas/UploadScanningScannerMode"
+          },
+          "antivirusScanningMode": {
+            "$ref": "#/components/schemas/UploadScanningScannerMode"
           }
         },
         "additionalProperties": false,
@@ -5825,6 +6890,20 @@
         },
         "additionalProperties": false,
         "description": "Response object for creating a new Shield Zone."
+      },
+      "CreateUnderAttackShieldZoneRequest": {
+        "required": ["planType", "pullZoneId"],
+        "type": "object",
+        "properties": {
+          "pullZoneId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "planType": {
+            "$ref": "#/components/schemas/ShieldPlanType"
+          }
+        },
+        "additionalProperties": false
       },
       "CreateWafRateLimitRequest": {
         "type": "object",
@@ -5956,6 +7035,14 @@
           },
           "value": {
             "type": "string",
+            "nullable": true
+          },
+          "isNegated": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "isRegexVariable": {
+            "type": "boolean",
             "nullable": true
           },
           "requestCount": {
@@ -6103,12 +7190,239 @@
       "DDoSExecutionMode": {
         "enum": [0, 1],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Log\n1 = Block",
+        "format": "int32",
+        "x-enum-varnames": ["Log", "Block"]
       },
       "DDoSShieldSensitivity": {
         "enum": [0, 1, 2, 3, 4],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Off\n1 = Low\n2 = Medium\n3 = High\n4 = Challenge",
+        "format": "int32",
+        "x-enum-varnames": ["Off", "Low", "Medium", "High", "Challenge"]
+      },
+      "EventGroup": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The group key: each requested groupBy dimension mapped to its value.",
+            "nullable": true
+          },
+          "count": {
+            "type": "integer",
+            "description": "Number of events in the group.",
+            "format": "int64"
+          },
+          "firstSeen": {
+            "type": "integer",
+            "description": "Earliest event time in the group (Unix time in milliseconds, UTC).",
+            "format": "int64"
+          },
+          "lastSeen": {
+            "type": "integer",
+            "description": "Most recent event time in the group (Unix time in milliseconds, UTC).",
+            "format": "int64"
+          },
+          "context": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Context aggregates for the group: country, asn, per-action counts (blocked/challenged/logged),\nand features/ruleIds touched. Counts are numbers; features/ruleIds are comma-joined strings.",
+            "nullable": true
+          },
+          "sparkline": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Per-group event counts bucketed across the requested window (mini time histogram), present only\nwhen the request set `buckets`. Bucket i covers [from + i*width, from + (i+1)*width).",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An aggregated group of events (returned when the search request specifies groupBy)."
+      },
+      "EventLogsExportRequest": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "integer",
+            "description": "Window start as Unix time in milliseconds (UTC). Required.",
+            "format": "int64"
+          },
+          "to": {
+            "type": "integer",
+            "description": "Window end as Unix time in milliseconds (UTC). Required; must be after BunnyNet.Shield.Api.Entities.Waf.WafLogging.EventLogsExportRequest.from and within the last 72 hours.",
+            "format": "int64"
+          },
+          "query": {
+            "type": "string",
+            "description": "Optional free-text search across IP, ruleId, URL, User-Agent and rule name.",
+            "nullable": true
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventLogsFilter"
+            },
+            "description": "Optional filters, combined with AND. Repeated values within one filter combine with OR.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request body for exporting a Shield Zone's full filtered Event Logs set as CSV."
+      },
+      "EventLogsFilter": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "Dimension to filter on: feature, ruleId, ip, ja4, ua, url, asn, country or action.",
+            "nullable": true
+          },
+          "op": {
+            "type": "string",
+            "description": "Operator: eq, in, contains, cidr (ip only, IPv4/IPv6) or wildcard ('*' matches any run).",
+            "nullable": true
+          },
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Value(s) for the filter; multiple values are OR-combined.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A single Event Logs filter clause."
+      },
+      "EventLogsSearchRequest": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "integer",
+            "description": "Window start as Unix time in milliseconds (UTC). Required.",
+            "format": "int64"
+          },
+          "to": {
+            "type": "integer",
+            "description": "Window end as Unix time in milliseconds (UTC). Required; must be after BunnyNet.Shield.Api.Entities.Waf.WafLogging.EventLogsSearchRequest.from and within the last 72 hours.",
+            "format": "int64"
+          },
+          "query": {
+            "type": "string",
+            "description": "Optional free-text search across IP, ruleId, URL, User-Agent and rule name.",
+            "nullable": true
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventLogsFilter"
+            },
+            "description": "Optional filters, combined with AND. Repeated values within one filter combine with OR.",
+            "nullable": true
+          },
+          "groupBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional ordered dimensions to group by, e.g. [\"ip\",\"ja4\"]. Omit for flat rows.\nAllowed: feature, ruleId, ip, ja4, ua, url, asn, country, action.",
+            "nullable": true
+          },
+          "buckets": {
+            "type": "integer",
+            "description": "When grouping, the number of time buckets for each group's sparkline histogram over the\nwindow. 0 (default) omits the sparkline; clamped to 500.",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Zero-based page index.",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "Page size; clamped to 1–500 (defaults to 50 when unset).",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request body for searching a Shield Zone's Event Logs within a time window."
+      },
+      "EventLogsSearchResponse": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventRow"
+            },
+            "description": "Flat event rows (populated when the request had no groupBy).",
+            "nullable": true
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventGroup"
+            },
+            "description": "Aggregated groups (populated when the request had a groupBy).",
+            "nullable": true
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total flat rows, or total distinct groups when grouped.",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number of pages for the current page size.",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Zero-based index of the returned page.",
+            "format": "int32"
+          },
+          "errorResponse": {
+            "$ref": "#/components/schemas/GenericRequestResponse"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Result of an Event Logs search. Exactly one of BunnyNet.Shield.Api.Entities.Waf.WafLogging.EventLogsSearchResponse.rows or BunnyNet.Shield.Api.Entities.Waf.WafLogging.EventLogsSearchResponse.groups is populated."
+      },
+      "EventRow": {
+        "type": "object",
+        "properties": {
+          "logId": {
+            "type": "string",
+            "description": "Unique event identifier.",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "Event time as Unix time in milliseconds (UTC).",
+            "format": "int64"
+          },
+          "log": {
+            "description": "The full request context for the event (JSON object).",
+            "nullable": true
+          },
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Resolved dimension values for the event (e.g. ip, ruleId, url, ja4).",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A single event returned in a flat (ungrouped) search."
       },
       "GenericRequestResponse": {
         "type": "object",
@@ -6210,6 +7524,18 @@
           },
           "data": {
             "$ref": "#/components/schemas/ShieldZoneBotDetectionMetrics"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetShieldZoneDefaultsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ShieldZoneDefaults"
+          },
+          "error": {
+            "$ref": "#/components/schemas/GenericRequestResponse"
           }
         },
         "additionalProperties": false
@@ -6391,7 +7717,77 @@
           506, 507, 508, 510, 511
         ],
         "type": "integer",
-        "format": "int32"
+        "description": "100 = Continue\n101 = SwitchingProtocols\n102 = Processing\n103 = EarlyHints\n200 = OK\n201 = Created\n202 = Accepted\n203 = NonAuthoritativeInformation\n204 = NoContent\n205 = ResetContent\n206 = PartialContent\n207 = MultiStatus\n208 = AlreadyReported\n226 = IMUsed\n300 = MultipleChoices\n300 = Ambiguous\n301 = MovedPermanently\n301 = Moved\n302 = Found\n302 = Redirect\n303 = SeeOther\n303 = RedirectMethod\n304 = NotModified\n305 = UseProxy\n306 = Unused\n307 = TemporaryRedirect\n307 = RedirectKeepVerb\n308 = PermanentRedirect\n400 = BadRequest\n401 = Unauthorized\n402 = PaymentRequired\n403 = Forbidden\n404 = NotFound\n405 = MethodNotAllowed\n406 = NotAcceptable\n407 = ProxyAuthenticationRequired\n408 = RequestTimeout\n409 = Conflict\n410 = Gone\n411 = LengthRequired\n412 = PreconditionFailed\n413 = RequestEntityTooLarge\n414 = RequestUriTooLong\n415 = UnsupportedMediaType\n416 = RequestedRangeNotSatisfiable\n417 = ExpectationFailed\n421 = MisdirectedRequest\n422 = UnprocessableEntity\n422 = UnprocessableContent\n423 = Locked\n424 = FailedDependency\n426 = UpgradeRequired\n428 = PreconditionRequired\n429 = TooManyRequests\n431 = RequestHeaderFieldsTooLarge\n451 = UnavailableForLegalReasons\n500 = InternalServerError\n501 = NotImplemented\n502 = BadGateway\n503 = ServiceUnavailable\n504 = GatewayTimeout\n505 = HttpVersionNotSupported\n506 = VariantAlsoNegotiates\n507 = InsufficientStorage\n508 = LoopDetected\n510 = NotExtended\n511 = NetworkAuthenticationRequired",
+        "format": "int32",
+        "x-enum-varnames": [
+          "Continue",
+          "SwitchingProtocols",
+          "Processing",
+          "EarlyHints",
+          "OK",
+          "Created",
+          "Accepted",
+          "NonAuthoritativeInformation",
+          "NoContent",
+          "ResetContent",
+          "PartialContent",
+          "MultiStatus",
+          "AlreadyReported",
+          "IMUsed",
+          "MultipleChoices",
+          "Ambiguous",
+          "MovedPermanently",
+          "Moved",
+          "Found",
+          "Redirect",
+          "SeeOther",
+          "RedirectMethod",
+          "NotModified",
+          "UseProxy",
+          "Unused",
+          "TemporaryRedirect",
+          "RedirectKeepVerb",
+          "PermanentRedirect",
+          "BadRequest",
+          "Unauthorized",
+          "PaymentRequired",
+          "Forbidden",
+          "NotFound",
+          "MethodNotAllowed",
+          "NotAcceptable",
+          "ProxyAuthenticationRequired",
+          "RequestTimeout",
+          "Conflict",
+          "Gone",
+          "LengthRequired",
+          "PreconditionFailed",
+          "RequestEntityTooLarge",
+          "RequestUriTooLong",
+          "UnsupportedMediaType",
+          "RequestedRangeNotSatisfiable",
+          "ExpectationFailed",
+          "MisdirectedRequest",
+          "UnprocessableEntity",
+          "UnprocessableContent",
+          "Locked",
+          "FailedDependency",
+          "UpgradeRequired",
+          "PreconditionRequired",
+          "TooManyRequests",
+          "RequestHeaderFieldsTooLarge",
+          "UnavailableForLegalReasons",
+          "InternalServerError",
+          "NotImplemented",
+          "BadGateway",
+          "ServiceUnavailable",
+          "GatewayTimeout",
+          "HttpVersionNotSupported",
+          "VariantAlsoNegotiates",
+          "InsufficientStorage",
+          "LoopDetected",
+          "NotExtended",
+          "NetworkAuthenticationRequired"
+        ]
       },
       "IOutputFormatter": {
         "type": "object",
@@ -6490,7 +7886,42 @@
       "MetricsOverviewResolution": {
         "enum": [0, 1, 2, 3, 4, 5, 6],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Auto\n1 = TwoMinutes\n2 = TenMinutes\n3 = Hourly\n4 = Daily\n5 = Weekly\n6 = Monthly",
+        "format": "int32",
+        "x-enum-varnames": [
+          "Auto",
+          "TwoMinutes",
+          "TenMinutes",
+          "Hourly",
+          "Daily",
+          "Weekly",
+          "Monthly"
+        ]
+      },
+      "OverageSegment": {
+        "type": "object",
+        "properties": {
+          "periodStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "planType": {
+            "$ref": "#/components/schemas/ShieldPlanType"
+          },
+          "overageAllowance": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "overage": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
       },
       "OverviewMetric": {
         "type": "object",
@@ -6625,7 +8056,16 @@
       "RateLimitTimeframe": {
         "enum": [1, 10, 60, 300, 900, 3600],
         "type": "integer",
-        "format": "int32"
+        "description": "1 = PerSecond\n10 = PerTenSeconds\n60 = PerOneMinute\n300 = PerFiveMinutes\n900 = PerFifteenMinutes\n3600 = PerOneHour",
+        "format": "int32",
+        "x-enum-varnames": [
+          "PerSecond",
+          "PerTenSeconds",
+          "PerOneMinute",
+          "PerFiveMinutes",
+          "PerFifteenMinutes",
+          "PerOneHour"
+        ]
       },
       "Ratelimit": {
         "type": "object",
@@ -6668,7 +8108,9 @@
       "RatelimitRuleActionType": {
         "enum": [1, 2, 3],
         "type": "integer",
-        "format": "int32"
+        "description": "1 = RateLimit\n2 = Log\n3 = Challenge",
+        "format": "int32",
+        "x-enum-varnames": ["RateLimit", "Log", "Challenge"]
       },
       "RequestIntegrityConfiguration": {
         "type": "object",
@@ -6682,7 +8124,9 @@
       "ReviewActionType": {
         "enum": [0, 1, 2],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Ignore\n1 = LogOnly\n2 = DisableRule",
+        "format": "int32",
+        "x-enum-varnames": ["Ignore", "LogOnly", "DisableRule"]
       },
       "ShieldOverview": {
         "type": "object",
@@ -6771,7 +8215,9 @@
       "ShieldPlanType": {
         "enum": [0, 1, 2, 3],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Basic\n1 = Advanced\n2 = Business\n3 = Enterprise",
+        "format": "int32",
+        "x-enum-varnames": ["Basic", "Advanced", "Business", "Enterprise"]
       },
       "ShieldZoneBotDetectionMetrics": {
         "type": "object",
@@ -6790,6 +8236,38 @@
           "totalChallengedRequests": {
             "type": "integer",
             "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ShieldZoneDefaults": {
+        "required": [
+          "accessLists",
+          "antivirusScanningMode",
+          "botDetectionExecutionMode",
+          "csamScanningMode",
+          "shieldZone"
+        ],
+        "type": "object",
+        "properties": {
+          "shieldZone": {
+            "$ref": "#/components/schemas/ShieldZoneRequest"
+          },
+          "botDetectionExecutionMode": {
+            "$ref": "#/components/schemas/BotDetectionExecutionMode"
+          },
+          "csamScanningMode": {
+            "$ref": "#/components/schemas/UploadScanningScannerMode"
+          },
+          "antivirusScanningMode": {
+            "$ref": "#/components/schemas/UploadScanningScannerMode"
+          },
+          "accessLists": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuggestedAccessList"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -6877,6 +8355,42 @@
           },
           "uploadScanning": {
             "$ref": "#/components/schemas/UploadScanning"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ShieldZoneMonthlyOveragesResult": {
+        "type": "object",
+        "properties": {
+          "shieldZoneId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "month": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalOverage": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalCleanRequests": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OverageSegment"
+            },
+            "nullable": true
+          },
+          "error": {
+            "$ref": "#/components/schemas/GenericRequestResponse"
           }
         },
         "additionalProperties": false
@@ -6985,6 +8499,14 @@
             },
             "nullable": true
           },
+          "wafCustomRuleOrder": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "nullable": true
+          },
           "wafRequestHeaderLoggingEnabled": {
             "type": "boolean",
             "nullable": true
@@ -7025,9 +8547,6 @@
           },
           "dDoSShieldSensitivity": {
             "$ref": "#/components/schemas/DDoSShieldSensitivity"
-          },
-          "dDoSExecutionMode": {
-            "$ref": "#/components/schemas/DDoSExecutionMode"
           },
           "dDoSChallengeWindow": {
             "type": "integer",
@@ -7082,6 +8601,14 @@
             "type": "array",
             "items": {
               "type": "string"
+            },
+            "nullable": true
+          },
+          "wafCustomRuleOrder": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
             },
             "nullable": true
           },
@@ -7175,6 +8702,31 @@
         },
         "additionalProperties": false
       },
+      "SuggestedAccessList": {
+        "required": ["action", "listId", "name", "requiredPlan"],
+        "type": "object",
+        "properties": {
+          "listId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "requiredPlan": {
+            "$ref": "#/components/schemas/ShieldPlanType"
+          },
+          "action": {
+            "$ref": "#/components/schemas/AccessListAction"
+          }
+        },
+        "additionalProperties": false
+      },
       "TriggeredRuleItem": {
         "type": "object",
         "properties": {
@@ -7246,7 +8798,9 @@
       "UnmatchedPathAction": {
         "enum": [0, 1, 2],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Block\n1 = Log\n2 = Ignore",
+        "format": "int32",
+        "x-enum-varnames": ["Block", "Log", "Ignore"]
       },
       "UpdateAccessListConfigurationRequest": {
         "type": "object",
@@ -7408,6 +8962,51 @@
         },
         "additionalProperties": false,
         "description": "Response for the PATCH /endpoint/{endpointId} endpoint."
+      },
+      "UpdateBotCategorizationConfigurationRequest": {
+        "required": ["action"],
+        "type": "object",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/BotCategorizationAction"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateBotCategorizationConfigurationResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/BotCategorizationDetails"
+          },
+          "error": {
+            "$ref": "#/components/schemas/GenericRequestResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateBotCategoryConfigurationRequest": {
+        "required": ["action"],
+        "type": "object",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/BotCategoryAction"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request body for setting a category-level action. Uses BunnyNet.Shield.Database.Enums.BotCategoryAction rather\nthan BunnyNet.Shield.Database.Enums.BotCategorizationAction so the contract can only express actions valid for a\ncategory (no Ignore)."
+      },
+      "UpdateBotCategoryConfigurationResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/BotCategoryDetails"
+          },
+          "error": {
+            "$ref": "#/components/schemas/GenericRequestResponse"
+          }
+        },
+        "additionalProperties": false
       },
       "UpdateBotDetectionRequest": {
         "type": "object",
@@ -7634,7 +9233,9 @@
       "UploadScanningScannerMode": {
         "enum": [0, 1, 2],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Disabled\n1 = Log\n2 = Block",
+        "format": "int32",
+        "x-enum-varnames": ["Disabled", "Log", "Block"]
       },
       "UpsertOpenApiSpecificationRequest": {
         "type": "object",
@@ -7669,12 +9270,16 @@
       "WAFExecutionMode": {
         "enum": [0, 1],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Log\n1 = Block",
+        "format": "int32",
+        "x-enum-varnames": ["Log", "Block"]
       },
       "WAFPayloadLimitAction": {
         "enum": [0, 1, 2],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = Block\n1 = Log\n2 = Ignore",
+        "format": "int32",
+        "x-enum-varnames": ["Block", "Log", "Ignore"]
       },
       "Waf": {
         "type": "object",
@@ -7795,6 +9400,14 @@
           "value": {
             "type": "string",
             "nullable": true
+          },
+          "isNegated": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "isRegexVariable": {
+            "type": "boolean",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -7843,6 +9456,12 @@
           "value": {
             "type": "integer",
             "format": "int32"
+          },
+          "supportedValues": {
+            "$ref": "#/components/schemas/WafSupportedValues"
+          },
+          "recommendedOperator": {
+            "$ref": "#/components/schemas/WafRecommendedOperator"
           }
         },
         "additionalProperties": false
@@ -7900,17 +9519,62 @@
       "WafRateLimitTimeframeType": {
         "enum": [1, 10, 60, 300, 900, 3600],
         "type": "integer",
-        "format": "int32"
+        "description": "1 = PerSecond\n10 = PerTenSeconds\n60 = PerOneMinute\n300 = PerFiveMinutes\n900 = PerFifteenMinutes\n3600 = PerOneHour",
+        "format": "int32",
+        "x-enum-varnames": [
+          "PerSecond",
+          "PerTenSeconds",
+          "PerOneMinute",
+          "PerFiveMinutes",
+          "PerFifteenMinutes",
+          "PerOneHour"
+        ]
       },
       "WafRatelimitBlockType": {
         "enum": [30, 60, 300, 900, 1800, 3600],
         "type": "integer",
-        "format": "int32"
+        "description": "30 = ForThirtySeconds\n60 = ForOneMinute\n300 = ForFiveMinutes\n900 = ForFifteenMinutes\n1800 = ForThirtyMinutes\n3600 = ForOneHour",
+        "format": "int32",
+        "x-enum-varnames": [
+          "ForThirtySeconds",
+          "ForOneMinute",
+          "ForFiveMinutes",
+          "ForFifteenMinutes",
+          "ForThirtyMinutes",
+          "ForOneHour"
+        ]
       },
       "WafRatelimitCounterKeyType": {
         "enum": [0, 1, 2, 3, 4, 5, 6, 7],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = IP\n1 = Host\n2 = Country\n3 = City\n4 = ASN\n5 = Organization\n6 = JA4\n7 = IP_JA4",
+        "format": "int32",
+        "x-enum-varnames": [
+          "IP",
+          "Host",
+          "Country",
+          "City",
+          "ASN",
+          "Organization",
+          "JA4",
+          "IP_JA4"
+        ]
+      },
+      "WafRecommendedOperator": {
+        "type": "object",
+        "properties": {
+          "operator": {
+            "$ref": "#/components/schemas/WafRuleOperatorType"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "WafRule": {
         "type": "object",
@@ -7937,7 +9601,9 @@
       "WafRuleActionType": {
         "enum": [1, 2, 3, 4, 5],
         "type": "integer",
-        "format": "int32"
+        "description": "1 = Block\n2 = Log\n3 = Challenge\n4 = Allow\n5 = Bypass",
+        "format": "int32",
+        "x-enum-varnames": ["Block", "Log", "Challenge", "Allow", "Bypass"]
       },
       "WafRuleGroupModel": {
         "type": "object",
@@ -8047,12 +9713,32 @@
       "WafRuleOperatorType": {
         "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 14, 15, 17, 18],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = BEGINSWITH\n1 = ENDSWITH\n2 = CONTAINS\n3 = CONTAINSWORD\n4 = STRMATCH\n5 = EQ\n6 = GE\n7 = GT\n8 = LE\n9 = LT\n12 = WITHIN\n14 = RX\n15 = STREQ\n17 = DETECTSQLI\n18 = DETECTXSS",
+        "format": "int32",
+        "x-enum-varnames": [
+          "BEGINSWITH",
+          "ENDSWITH",
+          "CONTAINS",
+          "CONTAINSWORD",
+          "STRMATCH",
+          "EQ",
+          "GE",
+          "GT",
+          "LE",
+          "LT",
+          "WITHIN",
+          "RX",
+          "STREQ",
+          "DETECTSQLI",
+          "DETECTXSS"
+        ]
       },
       "WafRuleSeverityType": {
         "enum": [0, 1, 2],
         "type": "integer",
-        "format": "int32"
+        "description": "0 = NOTICE\n1 = WARNING\n2 = CRITICAL",
+        "format": "int32",
+        "x-enum-varnames": ["NOTICE", "WARNING", "CRITICAL"]
       },
       "WafRuleTransformationType": {
         "enum": [
@@ -8060,7 +9746,31 @@
           21
         ],
         "type": "integer",
-        "format": "int32"
+        "description": "1 = CMDLINE\n2 = COMPRESSWHITESPACE\n3 = CSSDECODE\n4 = HEXENCODE\n5 = HTMLENTITYDECODE\n6 = JSDECODE\n7 = LENGTH\n8 = LOWERCASE\n9 = MD5\n10 = NORMALIZEPATH\n11 = NORMALISEPATH\n12 = NORMALIZEPATHWIN\n13 = NORMALISEPATHWIN\n14 = REMOVECOMMENTS\n15 = REMOVENULLS\n16 = REMOVEWHITESPACE\n17 = REPLACECOMMENTS\n18 = SHA1\n19 = URLDECODE\n20 = URLDECODEUNI\n21 = UTF8TOUNICODE",
+        "format": "int32",
+        "x-enum-varnames": [
+          "CMDLINE",
+          "COMPRESSWHITESPACE",
+          "CSSDECODE",
+          "HEXENCODE",
+          "HTMLENTITYDECODE",
+          "JSDECODE",
+          "LENGTH",
+          "LOWERCASE",
+          "MD5",
+          "NORMALIZEPATH",
+          "NORMALISEPATH",
+          "NORMALIZEPATHWIN",
+          "NORMALISEPATHWIN",
+          "REMOVECOMMENTS",
+          "REMOVENULLS",
+          "REMOVEWHITESPACE",
+          "REPLACECOMMENTS",
+          "SHA1",
+          "URLDECODE",
+          "URLDECODEUNI",
+          "UTF8TOUNICODE"
+        ]
       },
       "WafRulesByPlanModel": {
         "type": "object",
@@ -8079,6 +9789,22 @@
               "$ref": "#/components/schemas/WafRuleMainGroupModel"
             },
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "WafSupportedValues": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "editable": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/packages/openapi-client/specs/storage.json
+++ b/packages/openapi-client/specs/storage.json
@@ -15,11 +15,7 @@
       "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
     }
   },
-  "security": [
-    {
-      "AccessKeyAuthentication": []
-    }
-  ],
+  "security": [{ "AccessKeyAuthentication": [] }],
   "paths": {
     "/{storageZoneName}/{path}/{fileName}": {
       "get": {
@@ -32,36 +28,28 @@
             "in": "path",
             "description": "The name of your storage zone where you are connecting to.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "path",
             "in": "path",
             "description": "The directory path to your file. If this is the root of your storage zone, you can ignore this parameter.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "fileName",
             "in": "path",
             "description": "The name of the file that you wish to download.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "AccessKey",
             "in": "header",
             "required": true,
             "description": "The API AccessKey used for authentication.",
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           }
         ],
         "responses": {
@@ -74,9 +62,7 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorObject"
-                  }
+                  "items": { "$ref": "#/components/schemas/ErrorObject" }
                 }
               }
             }
@@ -88,22 +74,15 @@
         "summary": "Upload File",
         "description": "Upload a file to a storage zone based on the URL path. If the directory tree does not exist, it will be created automatically. **The file content should be sent as the body of the request without any type of encoding.**",
         "responses": {
-          "201": {
-            "description": "The file upload was successful."
-          },
-          "400": {
-            "description": "Upload failed."
-          }
+          "201": { "description": "The file upload was successful." },
+          "400": { "description": "Upload failed." }
         },
         "requestBody": {
           "description": "Raw request body should contain the contents of the file. This should be raw file data without any sort of encoding.",
           "required": true,
           "content": {
             "application/octet-stream": {
-              "schema": {
-                "type": "string",
-                "format": "binary"
-              }
+              "schema": { "type": "string", "format": "binary" }
             }
           }
         },
@@ -113,36 +92,28 @@
             "in": "path",
             "description": "he name of your storage zone where you are connecting to.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "path",
             "in": "path",
             "description": "The directory path to where your file will be stored. If this is the root of your storage zone, you can ignore this parameter.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "fileName",
             "in": "path",
             "description": "The name that the file will be uploaded as.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "Checksum",
             "in": "header",
             "required": false,
             "description": "The SHA256 checksum of the uploaded content in HEX format (UPPERCASE). The server will compare the final SHA256 to the checksum and reject the request in case the checksums do not match.",
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "example": "D7A8FBB307D7809469CA9ABCB0082E4F8D5651E46D3CDB762D02D0BF37C9E592"
           },
           {
@@ -150,9 +121,7 @@
             "in": "header",
             "required": true,
             "description": "The API AccessKey used for authentication.",
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           }
         ]
       },
@@ -166,45 +135,47 @@
             "in": "path",
             "description": "The name of your storage zone where you are connecting to.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "path",
             "in": "path",
             "description": "The directory path to your file. If this is the root of your storage zone, you can ignore this parameter.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "fileName",
             "in": "path",
             "description": "The name of the file that you wish to delete.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "AccessKey",
             "in": "header",
             "required": true,
             "description": "The API AccessKey used for authentication.",
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "allowRootDelete",
+            "in": "query",
+            "required": false,
+            "description": "Set to `true` to bypass the root directory deletion guard and delete the storage zone root (`/`).",
+            "schema": { "type": "string", "enum": ["true"] }
+          },
+          {
+            "name": "allowRootDelete",
+            "in": "header",
+            "required": false,
+            "description": "Set to `true` to bypass the root directory deletion guard and delete the storage zone root.",
+            "schema": { "type": "string", "enum": ["true"] }
           }
         ],
         "responses": {
-          "200": {
-            "description": "Object was successfully deleted"
-          },
-          "400": {
-            "description": "Object delete failed"
-          }
+          "200": { "description": "Object was successfully deleted" },
+          "400": { "description": "Object delete failed" }
         }
       }
     },
@@ -219,18 +190,14 @@
             "in": "path",
             "description": "he name of your storage zone where you are connecting to.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           },
           {
             "name": "path",
             "in": "path",
             "description": "The directory path that you want to list.",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "schema": { "type": "string" }
           }
         ],
         "responses": {
@@ -240,9 +207,7 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/StorageObject"
-                  }
+                  "items": { "$ref": "#/components/schemas/StorageObject" }
                 }
               },
               "application/json": {
@@ -285,11 +250,7 @@
       }
     }
   },
-  "servers": [
-    {
-      "url": "https://storage.bunnycdn.com/"
-    }
-  ],
+  "servers": [{ "url": "https://storage.bunnycdn.com/" }],
   "components": {
     "securitySchemes": {
       "AccessKeyAuthentication": {

--- a/packages/openapi-client/specs/stream.json
+++ b/packages/openapi-client/specs/stream.json
@@ -9,7 +9,7 @@
       "url": "https://docs.bunny.net",
       "email": "support@bunny.net"
     },
-    "version": "1.4.74"
+    "version": "1.5.17"
   },
   "servers": [
     {
@@ -1408,6 +1408,16 @@
               }
             }
           },
+          "400": {
+            "description": "The request or URL was invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "The requested video was not found"
           },
@@ -1416,6 +1426,16 @@
           },
           "403": {
             "description": "The request authorization failed"
+          },
+          "422": {
+            "description": "Unable to fetch thumbnail from origin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusModel"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error"
@@ -1492,7 +1512,24 @@
             "description": "The requested video was not found"
           },
           "400": {
-            "description": "Failed fetching the video"
+            "description": "URL validation failed or request was invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusModel"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unable to fetch video from origin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusModel"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too many fetch jobs queued. Please try again later.",
@@ -1574,7 +1611,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StatusModel"
+                  "$ref": "#/components/schemas/StatusModelOfCaptionValidationModel"
                 }
               }
             }
@@ -1587,7 +1624,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CaptionValidationModel"
+                  "$ref": "#/components/schemas/StatusModelOfCaptionValidationModel"
                 }
               }
             }
@@ -2460,6 +2497,11 @@
             "description": "The file name of the thumbnail inside of the storage",
             "nullable": true
           },
+          "thumbnailUrl": {
+            "type": "string",
+            "description": "The CDN URL of the thumbnail",
+            "nullable": true
+          },
           "thumbnailBlurhash": {
             "type": "string",
             "description": "Thumbnail blurhash to show while the actual thumbnail is being loaded",
@@ -2517,11 +2559,20 @@
             "nullable": true
           },
           "smartGenerateStatus": {
-            "description": "The status of smart generate action (if triggered)",
+            "description": "Aggregate smart generate status derived from per-feature statuses when present: InProgress, then Queued, then Failed, then Finished; otherwise the stored legacy value. See SmartGenerateFeaturesStatus.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/SmartGenerateStatus"
+              }
+            ]
+          },
+          "smartGenerateFeaturesStatus": {
+            "description": "Per-feature smart generate statuses (title, description, chapters, moments). Null for a feature on legacy rows.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SmartGenerateFeaturesStatusModel"
               }
             ]
           },
@@ -2544,17 +2595,52 @@
       "VideoModelStatus": {
         "type": "integer",
         "description": "",
-        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8],
-        "x-enum-varnames": [
-          "Created",
-          "Uploaded",
-          "Processing",
-          "Transcoding",
-          "Finished",
-          "Error",
-          "UploadFailed",
-          "JitSegmenting",
-          "JitPlaylistsCreated"
+        "oneOf": [
+          {
+            "title": "Created",
+            "type": "integer",
+            "enum": [0]
+          },
+          {
+            "title": "Uploaded",
+            "type": "integer",
+            "enum": [1]
+          },
+          {
+            "title": "Processing",
+            "type": "integer",
+            "enum": [2]
+          },
+          {
+            "title": "Transcoding",
+            "type": "integer",
+            "enum": [3]
+          },
+          {
+            "title": "Finished",
+            "type": "integer",
+            "enum": [4]
+          },
+          {
+            "title": "Error",
+            "type": "integer",
+            "enum": [5]
+          },
+          {
+            "title": "UploadFailed",
+            "type": "integer",
+            "enum": [6]
+          },
+          {
+            "title": "JitSegmenting",
+            "type": "integer",
+            "enum": [7]
+          },
+          {
+            "title": "JitPlaylistsCreated",
+            "type": "integer",
+            "enum": [8]
+          }
         ]
       },
       "CaptionModel": {
@@ -2657,59 +2743,183 @@
       "Severity": {
         "type": "integer",
         "description": "",
-        "enum": [0, 1, 2, 3],
-        "x-enum-varnames": ["Undefined", "Information", "Warning", "Error"],
-        "x-enum-descriptions": [
-          "Shouldn't be used",
-          "An info message to the user, shouldn't break anythying",
-          "A warning message, for example that the transcoded video may break when playing",
-          "An error, meaning that the video will most likely not be playable"
+        "oneOf": [
+          {
+            "title": "Undefined",
+            "type": "integer",
+            "description": "Shouldn't be used",
+            "enum": [0]
+          },
+          {
+            "title": "Information",
+            "type": "integer",
+            "description": "An info message to the user, shouldn't break anythying",
+            "enum": [1]
+          },
+          {
+            "title": "Warning",
+            "type": "integer",
+            "description": "A warning message, for example that the transcoded video may break when playing",
+            "enum": [2]
+          },
+          {
+            "title": "Error",
+            "type": "integer",
+            "description": "An error, meaning that the video will most likely not be playable",
+            "enum": [3]
+          }
         ]
       },
       "IssueCodes": {
         "type": "integer",
         "description": "",
-        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-        "x-enum-varnames": [
-          "Undefined",
-          "StreamLengthsDifference",
-          "TranscodingWarnings",
-          "IncompatibleResolution",
-          "InvalidFramerate",
-          "VideoExceededMaxDuration",
-          "AudioExceededMaxDuration",
-          "OriginalCorrupted",
-          "TranscriptionFailed",
-          "JitIncompatible",
-          "JitFailed",
-          "CaptionGenerationFailed"
-        ],
-        "x-enum-descriptions": [
-          "Shouldn't be used",
-          "Marks that there is a mismatch between lengths of audio and video streams in the transcoded file",
-          "Marks that transcoding completed with warnings",
-          "Marks that original video file has incompatible resolution or isn't a video stream",
-          "Marks that original video file has invalid framerate",
-          "Marks that video stream exceeded max duration",
-          "Marks that audio stream exceeded max duration",
-          "Marks that video file is corrupted and couldn't be processed properly",
-          "Marks that video transcription finished with errors and might not be complete",
-          "Marks that video file is not compatible with JIT encoding",
-          "Marks that video failed JIT encoding",
-          "Marks that captions generation failed"
+        "oneOf": [
+          {
+            "title": "Undefined",
+            "type": "integer",
+            "description": "Shouldn't be used",
+            "enum": [0]
+          },
+          {
+            "title": "StreamLengthsDifference",
+            "type": "integer",
+            "description": "Marks that there is a mismatch between lengths of audio and video streams in the transcoded file",
+            "enum": [1]
+          },
+          {
+            "title": "TranscodingWarnings",
+            "type": "integer",
+            "description": "Marks that transcoding completed with warnings",
+            "enum": [2]
+          },
+          {
+            "title": "IncompatibleResolution",
+            "type": "integer",
+            "description": "Marks that original video file has incompatible resolution or isn't a video stream",
+            "enum": [3]
+          },
+          {
+            "title": "InvalidFramerate",
+            "type": "integer",
+            "description": "Marks that original video file has invalid framerate",
+            "enum": [4]
+          },
+          {
+            "title": "VideoExceededMaxDuration",
+            "type": "integer",
+            "description": "Marks that video stream exceeded max duration",
+            "enum": [5]
+          },
+          {
+            "title": "AudioExceededMaxDuration",
+            "type": "integer",
+            "description": "Marks that audio stream exceeded max duration",
+            "enum": [6]
+          },
+          {
+            "title": "OriginalCorrupted",
+            "type": "integer",
+            "description": "Marks that video file is corrupted and couldn't be processed properly",
+            "enum": [7]
+          },
+          {
+            "title": "TranscriptionFailed",
+            "type": "integer",
+            "description": "Marks that video transcription finished with errors and might not be complete",
+            "enum": [8]
+          },
+          {
+            "title": "JitIncompatible",
+            "type": "integer",
+            "description": "Marks that video file is not compatible with JIT encoding",
+            "enum": [9]
+          },
+          {
+            "title": "JitFailed",
+            "type": "integer",
+            "description": "Marks that video failed JIT encoding",
+            "enum": [10]
+          },
+          {
+            "title": "CaptionGenerationFailed",
+            "type": "integer",
+            "description": "Marks that captions generation failed",
+            "enum": [11]
+          }
         ]
       },
       "SmartGenerateStatus": {
         "type": "integer",
         "description": "",
-        "enum": [0, 1, 2, 3, 4],
-        "x-enum-varnames": [
-          "None",
-          "Queued",
-          "InProgress",
-          "Finished",
-          "Failed"
+        "oneOf": [
+          {
+            "title": "None",
+            "type": "integer",
+            "enum": [0]
+          },
+          {
+            "title": "Queued",
+            "type": "integer",
+            "enum": [1]
+          },
+          {
+            "title": "InProgress",
+            "type": "integer",
+            "enum": [2]
+          },
+          {
+            "title": "Finished",
+            "type": "integer",
+            "enum": [3]
+          },
+          {
+            "title": "Failed",
+            "type": "integer",
+            "enum": [4]
+          }
         ]
+      },
+      "SmartGenerateFeaturesStatusModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "description": "Smart generate status for the video title, when applicable.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SmartGenerateStatus"
+              }
+            ]
+          },
+          "description": {
+            "description": "Smart generate status for the video description, when applicable.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SmartGenerateStatus"
+              }
+            ]
+          },
+          "chapters": {
+            "description": "Smart generate status for chapters, when applicable.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SmartGenerateStatus"
+              }
+            ]
+          },
+          "moments": {
+            "description": "Smart generate status for moments, when applicable.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SmartGenerateStatus"
+              }
+            ]
+          }
+        }
       },
       "VideoHeatmapModel": {
         "type": "object",
@@ -2742,6 +2952,10 @@
           "libraryName": {
             "type": "string",
             "nullable": true
+          },
+          "pullZoneId": {
+            "type": "integer",
+            "format": "int64"
           },
           "captionsPath": {
             "type": "string",
@@ -2835,6 +3049,18 @@
             "format": "int32",
             "nullable": true
           },
+          "widevineEmeRobustness": {
+            "type": "string",
+            "nullable": true
+          },
+          "widevineSdOnlyForL3": {
+            "type": "boolean"
+          },
+          "maxSoftwareWidevineResolution": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
           "zoneTier": {
             "type": "integer",
             "format": "int32",
@@ -2874,8 +3100,23 @@
       "VideoPlaybackSource": {
         "type": "string",
         "description": "",
-        "enum": ["None", "Playlist", "Original"],
-        "x-enum-varnames": ["None", "Playlist", "Original"]
+        "oneOf": [
+          {
+            "title": "None",
+            "type": "string",
+            "enum": ["None"]
+          },
+          {
+            "title": "Playlist",
+            "type": "string",
+            "enum": ["Playlist"]
+          },
+          {
+            "title": "Original",
+            "type": "string",
+            "enum": ["Original"]
+          }
+        ]
       },
       "VideoStatisticsModel": {
         "type": "object",
@@ -2927,8 +3168,28 @@
       "EncoderOutputCodec": {
         "type": "integer",
         "description": "",
-        "enum": [0, 1, 2, 3],
-        "x-enum-varnames": ["x264", "vp9", "hevc", "av1"]
+        "oneOf": [
+          {
+            "title": "x264",
+            "type": "integer",
+            "enum": [0]
+          },
+          {
+            "title": "vp9",
+            "type": "integer",
+            "enum": [1]
+          },
+          {
+            "title": "hevc",
+            "type": "integer",
+            "enum": [2]
+          },
+          {
+            "title": "av1",
+            "type": "integer",
+            "enum": [3]
+          }
+        ]
       },
       "PaginationListOfVideoModel": {
         "type": "object",
@@ -3047,6 +3308,27 @@
           }
         }
       },
+      "StatusModelOfCaptionValidationModel": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/StatusModel"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CaptionValidationModel"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
       "CaptionValidationModel": {
         "type": "object",
         "additionalProperties": false,
@@ -3070,6 +3352,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "warningMessage": {
+            "type": "string",
+            "description": "UI-friendly summary of warnings found in the uploaded captions file",
+            "nullable": true
           }
         }
       },
@@ -3425,6 +3712,16 @@
             "type": "string",
             "nullable": true
           },
+          "thumbnail_width": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "thumbnail_height": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
           "width": {
             "type": "integer",
             "format": "int32"
@@ -3444,45 +3741,6 @@
           "provider_url": {
             "type": "string",
             "nullable": true
-          }
-        }
-      },
-      "SyncSessionResponse": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "error": {
-            "type": "string",
-            "nullable": true
-          },
-          "success": {
-            "type": "boolean"
-          },
-          "sessionKey": {
-            "type": "string",
-            "nullable": true
-          },
-          "rocksDbInfo": {
-            "$ref": "#/components/schemas/RocksDbInfo"
-          }
-        }
-      },
-      "RocksDbInfo": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "version": {
-            "type": "string"
-          }
-        }
-      },
-      "SyncSessionRequest": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "lastSequenceNumber": {
-            "type": "integer",
-            "format": "int64"
           }
         }
       }

--- a/packages/sandbox/src/provision.ts
+++ b/packages/sandbox/src/provision.ts
@@ -189,7 +189,7 @@ export async function createApp(
           {
             displayName: "ssh",
             anycast: {
-              type: "ipv4",
+              type: "iPv4",
               portMappings: [
                 {
                   containerPort: SSH_PORT,

--- a/packages/scriptable-dns-types/README.md
+++ b/packages/scriptable-dns-types/README.md
@@ -1,6 +1,6 @@
 # @bunny.net/scriptable-dns-types
 
-Ambient TypeScript types for the [bunny.net Scriptable DNS](https://docs.bunny.net/docs/dns-scripting) runtime.
+Ambient TypeScript types for the [bunny.net Scriptable DNS](https://bunny.net/docs/dns/scriptable/introduction) runtime.
 
 Scriptable DNS scripts run with a set of globals injected by the runtime (`ARecord`, `Monitoring`, `RoutingEngine`, and so on). Because the runtime does not support `import`, these are provided as ambient declarations: they power editor autocomplete and an optional typecheck step, but are never imported at runtime.
 


### PR DESCRIPTION
## What changed

Three related things, all following from the docs site moving to `bunny.net/docs`, kept in one PR.

**1. Spec source URLs.** Two of the eight source URLs in `update-specs.ts` were resolving through a 302. Cross-checked every entry against the canonical list at https://bunny.net/docs/openapi; the other six already matched and are untouched. Also completed the spec table in `AGENTS.md`, which listed only 4 of the 8 specs.

**2. Refreshed all specs.** The committed specs had drifted well behind upstream. Nothing was removed; every change is additive at the path level.

New paths now available:

| Spec | New paths |
| --- | --- |
| `core` | `/pullzone/requestExternalHttpCertificate`, `/pullzone/completeExternalHttpCertificate`, `/storagezone/{id}/statistics/egress`, `/v1/pricing/{source}/{resourceId}` |
| `magic-containers` | `/registries/image-config` |
| `shield` | 8 paths including `/shield/event-logs/{shieldZoneId}/search`, `/shield/shield-zone/under-attack`, and bot-categorization |

Also: `allowRootDelete` on the storage delete endpoint, and `ScopedApiKey` added to the compute API key role enum. `database.json` is unchanged and `origin-errors.json` is formatting-only churn, refreshed so that re-running the update plus formatter is idempotent.

**3. Documentation links.** `DOCS_BASE_URL` drives `bunny docs` plus the `db`, `scripts`, and `storage` docs subcommands, so all four were opening a redirect. All four new URLs resolve directly with a 200.

While checking those, found a genuinely broken link in the `scriptable-dns-types` README: `docs.bunny.net/docs/dns-scripting` redirects to `bunny.net/docs/dns-scripting`, which 404s. The page now lives at `bunny.net/docs/dns/scriptable/introduction`. Fixed, since that README ships to npm.

The `docs.bunny.net` URLs still in the specs are upstream `info.contact.url` fields, left as downloaded so the next refresh does not fight the edit.

## Code changes the refresh required

**`AnycastIpProtocolVersion` changed from `ipv4` to `iPv4`.** All four call sites now send the documented value. Two of them build loosely typed request bodies, so `tsc` could not flag them and they would have silently kept sending the old value:

- `packages/config/src/convert.ts` (typecheck caught this)
- `packages/cli/src/commands/apps/endpoints/add.ts` (untyped, `body as any`)
- `packages/sandbox/src/provision.ts` (untyped, SSH endpoint for every sandbox)
- plus two test assertions

**`ContainerEndpoint` now carries a required `id`**, described upstream as the value to pass as `container_endpoint_id` when creating a pull zone that targets the endpoint. Two test fixtures that predate it grew one.

## The one thing to check before merging

The `iPv4` casing looks like a .NET enum serialization change (`IPv4` under a camelCase policy) rather than a deliberate API change, and ASP.NET Core deserializes string enums case-insensitively by default, so `ipv4` was most likely still being accepted. **This has not been verified against the live API**, because confirming it means actually creating an anycast endpoint. Following the spec is the safer default of the two, but if you want certainty before this ships, creating one anycast endpoint would settle it.

Worth noting the blast radius if the casing does matter: `packages/sandbox/src/provision.ts` sends this on every sandbox provision, not just on explicit `apps endpoints add --type anycast`.

## Changesets

| Package | Bump | Why |
| --- | --- | --- |
| `@bunny.net/openapi-client` | patch | spec refresh |
| `@bunny.net/cli` | patch | anycast value, docs URLs |
| `@bunny.net/sandbox` | patch | anycast value |
| `@bunny.net/scriptable-dns-types` | patch | dead README link |

`@bunny.net/config` is private so it needs none; its change reaches users through the CLI.

Flagging that the enum change is arguably breaking for `@bunny.net/openapi-client` consumers who typed against `"ipv4"`, which would make it a minor. Patch as requested; it is a one-word edit either way.

## Verification

- `bun run typecheck` clean
- `bun test` 830 pass, 1 skip, 0 fail
- `bun run lint:prettier:ci` clean, `biome ci` clean for every file this PR touches
- Every documentation URL this PR introduces confirmed 200

Pre-existing and not from this PR: `packages/cli/src/commands/sites/deploy.test.ts` already fails `biome ci` formatting on `main`. Left alone to keep this diff scoped.
