### PR TITLE
feat(openapi-client): export authMiddleware, per-API entrypoints, npm metadata

### DIFF
--- a/.changeset/openapi-client-entrypoints-metadata.md
+++ b/.changeset/openapi-client-entrypoints-metadata.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/openapi-client": minor
+---
+
+Standalone-library DX improvements: export `authMiddleware` so custom `openapi-fetch` clients can reuse the shared auth/error-normalization middleware; add per-API subpath entrypoints (`@bunny.net/openapi-client/core`, `/compute`, `/database`, `/magic-containers`, `/origin-errors`, `/shield`, `/storage`, `/stream`) that bundle each client factory with its generated spec types (the `generated/*` paths remain for backwards compatibility); and fill in npm metadata — license (MIT, with a bundled LICENSE file), description, repository, homepage, bugs, keywords, `sideEffects: false`, and an `engines` field (Node ≥ 18).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ bunny-cli/
 │   │   ├── scripts/
 │   │   │   └── update-specs.ts           # Downloads latest specs from bunny.net endpoints
 │   │   └── src/
-│   │       ├── index.ts                  # Barrel export: clients, errors, ClientOptions type, DNS scan type corrections
+│   │       ├── index.ts                  # Barrel export: clients, authMiddleware, errors, ClientOptions type, DNS scan type corrections
+│   │       ├── core.ts … stream.ts       # Per-API subpath entrypoints (core, compute, database, magic-containers, origin-errors, shield, storage, stream): each re-exports its client factory + generated spec types (backs the package.json "./<api>" exports)
 │   │       ├── middleware.ts             # authMiddleware(options) — dependency-inverted (no CLI imports)
 │   │       ├── errors.ts                 # UserError, ApiError classes
 │   │       ├── dns.ts                    # Hand-authored corrections for lossy generated DNS types: DnsDiscoveredRecord (adds Flags/Tag the scan returns but generation drops), DnsRecordScanJob/Trigger, DnsRecordScanStatus enum. Pattern for enriching generated types.
@@ -485,7 +486,7 @@ bunny-cli/
 - **Shared internal code lives in `packages/cli/src/core/`** — command factories, errors, logger, format utilities, UI helpers, and shared types. Keep this mostly flat; a cohesive, reusable feature spanning several files may use a subdirectory (e.g. `core/hostnames/` — the pull-zone hostname helpers + the `createHostnamesCommands` factory mounted by both `scripts` and, in future, `apps`).
 - **Config logic lives in `packages/cli/src/config/`** — schema, file resolution, and profile management.
 - **Error classes are split.** `UserError` and `ApiError` live in `@bunny.net/openapi-client` (the SDK needs them). `ConfigError` lives in the CLI and extends `UserError`. The CLI's `errors.ts` re-exports `UserError` and `ApiError` from `@bunny.net/openapi-client`.
-- **Import API clients from `@bunny.net/openapi-client`**, not relative paths. Import generated types from `@bunny.net/openapi-client/generated/<spec>.d.ts`.
+- **Import API clients from `@bunny.net/openapi-client`**, not relative paths. Import generated types from the per-API entrypoints (`@bunny.net/openapi-client/<spec>`, e.g. `@bunny.net/openapi-client/core`); the older `@bunny.net/openapi-client/generated/<spec>.d.ts` paths remain supported.
 - **Mask secrets in human output; reveal only behind an explicit flag.** Any sensitive value (API keys, passwords, S3 secret keys, auth tokens) must be masked in the default table/text output and shown in full only when the user opts in with a flag (e.g. `--show-secret`). Use `maskSecret()` from `core/format.ts` for the masked form (it keeps the last 4 characters for identification). Tool-config output (`--format rclone|aws|...`) is the exception because it exists to be consumed by tools: it always emits full values. `--output json` masks like the table; `--show-secret` reveals there too. Never print a secret the user did not explicitly ask to see. Reference: `storage zones credentials` masks the S3 secret access key by default in both the table and JSON and reveals it with `--show-secret`, while never leaking it from inspect/list commands (see `toSafeStorageZone`).
 - **Pull-zone settings are exposed via "Hybrid D" across surfaces.** Scripts and apps are backed by a pull zone, which has a large settings surface (hostnames, caching, edge rules, origin, security, purge, CORS, optimizer, logging, …). To keep each owner's help legible:
   - **Flatten only first-class groups** directly into the owner — picked by user mental model, kept to one or two. `scripts domains` is the flattened group (a custom domain is "my site's address," not a CDN setting).
@@ -926,7 +927,7 @@ Its `package.json` `exports`/`main`/`types` point at `dist/`, so npm consumers g
 
 - `bun run --filter @bunny.net/openapi-client build` runs `generate` (the `src/generated/` types are gitignored, so they are regenerated from the committed specs), then `scripts/build.ts`.
 - `scripts/build.ts` drives the TypeScript compiler API (using `tsconfig.build.json`) to emit JS + declarations, then copies the generated `.d.ts` files into `dist/generated/` (tsc never emits its inputs, and those files back the `./generated/*` subpath export). `rewriteRelativeImportExtensions` rewrites `./x.ts` → `./x.js` in the emitted **JS**; TypeScript has no equivalent for declaration emit, so an `afterDeclarations` transformer rewrites the `.ts`/`.d.ts` specifiers in the emitted **`.d.ts`** files on the AST.
-- The `publish-openapi-client` job in `release.yml` (gated on a version bump detected via `npm view`) builds, then runs `cd packages/openapi-client && npm publish` (`files` ships `dist` + `README.md`). The package versions independently of the CLI — it is not part of any `fixed` group in `.changeset/config.json`.
+- The `publish-openapi-client` job in `release.yml` (gated on a version bump detected via `npm view`) builds, then runs `cd packages/openapi-client && npm publish` (`files` ships `dist` + `README.md` + `LICENSE`). The package versions independently of the CLI — it is not part of any `fixed` group in `.changeset/config.json`.
 
 ### Publishing `@bunny.net/sandbox`
 
@@ -1161,7 +1162,7 @@ API calls use `openapi-fetch` with types generated from OpenAPI specs by `openap
 | Storage                  | `createStorageClient()`      | `https://storage.bunnycdn.com`         | Storage Zone password  |
 | Stream                   | `createStreamClient()`       | `https://video.bunnycdn.com`           | Stream Library API key |
 
-All clients accept a `ClientOptions` object and inject `AccessKey` and `User-Agent` headers via shared `authMiddleware()` in `packages/openapi-client/src/middleware.ts`.
+All clients accept a `ClientOptions` object and inject `AccessKey` and `User-Agent` headers via shared `authMiddleware()` in `packages/openapi-client/src/middleware.ts` (also exported from the package root so external consumers can compose custom `openapi-fetch` clients). Each API additionally has a subpath entrypoint (`@bunny.net/openapi-client/<api>`) re-exporting its factory plus the generated spec types.
 
 ### ClientOptions
 
@@ -1253,6 +1254,7 @@ handler: async ({ profile, apiKey, verbose }) => {
 2. Add an entry to `packages/openapi-client/redocly.yaml`.
 3. Run `bun run openapi:generate`.
 4. Create a client factory in `packages/openapi-client/src/` following the existing pattern and export it from `packages/openapi-client/src/index.ts`.
+5. Add a per-API entrypoint module (`packages/openapi-client/src/<api>.ts` re-exporting the factory + `export type * from "./generated/<spec>.d.ts"`) and a matching `./<api>` entry in the package `exports` map.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ This is a Bun workspace monorepo with five packages:
 - Handle `--output json` first in every handler, then pass `output` to format functions.
 - Use `logger` from `packages/cli/src/core/logger.ts` for all user-facing output.
 - Throw `UserError` for expected errors.
-- Import API clients from `@bunny.net/openapi-client`, not relative paths. Import generated types from `@bunny.net/openapi-client/generated/<spec>.d.ts`.
+- Import API clients from `@bunny.net/openapi-client`, not relative paths. Import generated types from the per-API entrypoints (`@bunny.net/openapi-client/<spec>`, e.g. `@bunny.net/openapi-client/core`); the older `generated/<spec>.d.ts` paths remain supported.
 - Use `clientOptions(config, verbose)` from `packages/cli/src/core/client-options.ts` when creating API clients in command handlers.
 - Database commands use v2 API endpoints (`/v2/databases/...`).
 - Apps (Magic Containers) commands use `bunny.jsonc` as the single source of truth. App ID is stored in the config (no separate manifest file). Use `resolveAppId()` and `resolveContainerId()` from `packages/cli/src/commands/apps/config.ts`. Types and conversion functions come from `@bunny.net/config`.

--- a/packages/openapi-client/LICENSE
+++ b/packages/openapi-client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BunnyWay d.o.o.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/openapi-client/README.md
+++ b/packages/openapi-client/README.md
@@ -6,7 +6,11 @@ Standalone, type-safe OpenAPI client for [bunny.net](https://bunny.net). Zero CL
 
 ```bash
 bun add @bunny.net/openapi-client
+# or
+npm install @bunny.net/openapi-client
 ```
+
+Requires a runtime with a global `fetch` (Node.js ≥ 18, Bun, Deno, edge runtimes). ESM-only.
 
 ## Usage
 
@@ -73,26 +77,43 @@ try {
 - `UserError` — expected errors (bad input, missing config). Has an optional `hint` property.
 - `ApiError` — extends `UserError`. Carries `status`, optional `field`, and optional `validationErrors[]`.
 
-## Generated Types
+## Per-API Entrypoints
 
-TypeScript types are generated from OpenAPI specs via `openapi-typescript`. Access them through the `generated` export:
+Each API also has its own subpath entrypoint exporting the client factory together with every type generated from that API's OpenAPI spec (`paths`, `components`, `operations`):
 
 ```typescript
-import type { components } from "@bunny.net/openapi-client/generated/core.d.ts";
+import { createCoreClient } from "@bunny.net/openapi-client/core";
+import type { components } from "@bunny.net/openapi-client/core";
 
-type PullZone = components["schemas"]["PullZone"];
+type DnsZone = components["schemas"]["DnsZoneModel"];
 ```
 
-Available type modules:
+| Entrypoint                                   | Exports                                              |
+| -------------------------------------------- | ---------------------------------------------------- |
+| `@bunny.net/openapi-client/core`             | `createCoreClient`, core spec types, DNS scan types  |
+| `@bunny.net/openapi-client/compute`          | `createComputeClient`, compute spec types            |
+| `@bunny.net/openapi-client/database`         | `createDbClient`, database spec types                |
+| `@bunny.net/openapi-client/magic-containers` | `createMcClient`, Magic Containers spec types        |
+| `@bunny.net/openapi-client/origin-errors`    | `createOriginErrorsClient`, origin-errors spec types |
+| `@bunny.net/openapi-client/shield`           | `createShieldClient`, shield spec types              |
+| `@bunny.net/openapi-client/storage`          | `createStorageClient`, storage spec types            |
+| `@bunny.net/openapi-client/stream`           | `createStreamClient`, stream spec types              |
 
-- `@bunny.net/openapi-client/generated/core.d.ts`
-- `@bunny.net/openapi-client/generated/compute.d.ts`
-- `@bunny.net/openapi-client/generated/database.d.ts`
-- `@bunny.net/openapi-client/generated/magic-containers.d.ts`
-- `@bunny.net/openapi-client/generated/origin-errors.d.ts`
-- `@bunny.net/openapi-client/generated/shield.d.ts`
-- `@bunny.net/openapi-client/generated/storage.d.ts`
-- `@bunny.net/openapi-client/generated/stream.d.ts`
+The raw generated modules remain available at `@bunny.net/openapi-client/generated/<spec>.d.ts` for backwards compatibility.
+
+## Custom Clients
+
+The shared middleware — auth-header injection, debug logging, and error normalization — is exported as `authMiddleware`, so you can compose your own `openapi-fetch` client (for example, over a spec of your own or with extra middleware) and keep the same behavior:
+
+```typescript
+import createClient from "openapi-fetch";
+import { authMiddleware } from "@bunny.net/openapi-client";
+import type { paths } from "@bunny.net/openapi-client/core";
+
+const client = createClient<paths>({ baseUrl: "https://api.bunny.net" });
+client.use(authMiddleware({ apiKey: "bny_xxxxxxxxxxxx" }));
+client.use(myLoggingMiddleware);
+```
 
 ## Updating Specs
 

--- a/packages/openapi-client/package.json
+++ b/packages/openapi-client/package.json
@@ -1,7 +1,32 @@
 {
   "name": "@bunny.net/openapi-client",
   "version": "0.2.0",
+  "description": "Type-safe TypeScript client for the bunny.net APIs (CDN, DNS, Edge Storage, Stream, Shield, Magic Containers), generated from official OpenAPI specs.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BunnyWay/cli.git",
+    "directory": "packages/openapi-client"
+  },
+  "homepage": "https://github.com/BunnyWay/cli/tree/main/packages/openapi-client#readme",
+  "bugs": "https://github.com/BunnyWay/cli/issues",
+  "keywords": [
+    "bunny",
+    "bunny.net",
+    "bunnycdn",
+    "cdn",
+    "dns",
+    "edge-storage",
+    "stream",
+    "api-client",
+    "openapi",
+    "typescript"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,11 +40,44 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "import": "./dist/core.js"
+    },
+    "./compute": {
+      "types": "./dist/compute.d.ts",
+      "import": "./dist/compute.js"
+    },
+    "./database": {
+      "types": "./dist/database.d.ts",
+      "import": "./dist/database.js"
+    },
+    "./magic-containers": {
+      "types": "./dist/magic-containers.d.ts",
+      "import": "./dist/magic-containers.js"
+    },
+    "./origin-errors": {
+      "types": "./dist/origin-errors.d.ts",
+      "import": "./dist/origin-errors.js"
+    },
+    "./shield": {
+      "types": "./dist/shield.d.ts",
+      "import": "./dist/shield.js"
+    },
+    "./storage": {
+      "types": "./dist/storage.d.ts",
+      "import": "./dist/storage.js"
+    },
+    "./stream": {
+      "types": "./dist/stream.d.ts",
+      "import": "./dist/stream.js"
+    },
     "./generated/*": "./dist/generated/*"
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/openapi-client/src/compute.ts
+++ b/packages/openapi-client/src/compute.ts
@@ -1,0 +1,3 @@
+/** Edge Scripting API entrypoint: client factory + generated spec types. */
+export { createComputeClient } from "./compute-client.ts";
+export type * from "./generated/compute.d.ts";

--- a/packages/openapi-client/src/core.ts
+++ b/packages/openapi-client/src/core.ts
@@ -1,0 +1,13 @@
+/**
+ * Core API entrypoint: the client factory plus every type generated from the
+ * core OpenAPI spec (`paths`, `components`, `operations`), so consumers can
+ * write `import type { components } from "@bunny.net/openapi-client/core"`.
+ */
+export { createCoreClient } from "./core-client.ts";
+export type {
+  DnsDiscoveredRecord,
+  DnsRecordScanJob,
+  DnsRecordScanTrigger,
+} from "./dns.ts";
+export { DnsRecordScanStatus } from "./dns.ts";
+export type * from "./generated/core.d.ts";

--- a/packages/openapi-client/src/database.ts
+++ b/packages/openapi-client/src/database.ts
@@ -1,0 +1,3 @@
+/** Database API entrypoint: client factory + generated spec types. */
+export { createDbClient } from "./db-client.ts";
+export type * from "./generated/database.d.ts";

--- a/packages/openapi-client/src/entrypoints.test.ts
+++ b/packages/openapi-client/src/entrypoints.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { createComputeClient } from "./compute.ts";
+import type { components } from "./core.ts";
+import { createCoreClient, DnsRecordScanStatus } from "./core.ts";
+import { createDbClient } from "./database.ts";
+import * as root from "./index.ts";
+import { createMcClient } from "./magic-containers.ts";
+import { createOriginErrorsClient } from "./origin-errors.ts";
+import { createShieldClient } from "./shield.ts";
+import { createStorageClient } from "./storage.ts";
+import { createStreamClient } from "./stream.ts";
+
+describe("root entrypoint", () => {
+  test("exports authMiddleware for composing custom clients", () => {
+    expect(typeof root.authMiddleware).toBe("function");
+    const middleware = root.authMiddleware({ apiKey: "k" });
+    expect(typeof middleware.onRequest).toBe("function");
+    expect(typeof middleware.onResponse).toBe("function");
+  });
+});
+
+describe("per-API entrypoints", () => {
+  test("re-export the same factories as the root entrypoint", () => {
+    expect(createCoreClient).toBe(root.createCoreClient);
+    expect(createComputeClient).toBe(root.createComputeClient);
+    expect(createDbClient).toBe(root.createDbClient);
+    expect(createMcClient).toBe(root.createMcClient);
+    expect(createOriginErrorsClient).toBe(root.createOriginErrorsClient);
+    expect(createShieldClient).toBe(root.createShieldClient);
+    expect(createStorageClient).toBe(root.createStorageClient);
+    expect(createStreamClient).toBe(root.createStreamClient);
+  });
+
+  test("core entrypoint carries the DNS scan corrections", () => {
+    expect(DnsRecordScanStatus.Completed).toBe(
+      root.DnsRecordScanStatus.Completed,
+    );
+  });
+
+  test("generated spec types are importable from the entrypoint", () => {
+    // Compile-time assertion: `components` resolves from ./core.ts.
+    const zone: Pick<components["schemas"]["DnsZoneModel"], "Domain"> = {
+      Domain: "example.com",
+    };
+    expect(zone.Domain).toBe("example.com");
+  });
+});

--- a/packages/openapi-client/src/index.ts
+++ b/packages/openapi-client/src/index.ts
@@ -9,7 +9,7 @@ export type {
 export { DnsRecordScanStatus } from "./dns.ts";
 export { ApiError, UserError } from "./errors.ts";
 export { createMcClient } from "./mc-client.ts";
-export type { ClientOptions } from "./middleware.ts";
+export { authMiddleware, type ClientOptions } from "./middleware.ts";
 export { createOriginErrorsClient } from "./origin-errors-client.ts";
 export { createShieldClient } from "./shield-client.ts";
 export { createStorageClient } from "./storage-client.ts";

--- a/packages/openapi-client/src/magic-containers.ts
+++ b/packages/openapi-client/src/magic-containers.ts
@@ -1,0 +1,4 @@
+/** Magic Containers API entrypoint: client factory + generated spec types. */
+
+export type * from "./generated/magic-containers.d.ts";
+export { createMcClient } from "./mc-client.ts";

--- a/packages/openapi-client/src/origin-errors.ts
+++ b/packages/openapi-client/src/origin-errors.ts
@@ -1,0 +1,4 @@
+/** Origin Errors API entrypoint: client factory + generated spec types. */
+
+export type * from "./generated/origin-errors.d.ts";
+export { createOriginErrorsClient } from "./origin-errors-client.ts";

--- a/packages/openapi-client/src/shield.ts
+++ b/packages/openapi-client/src/shield.ts
@@ -1,0 +1,4 @@
+/** Shield API entrypoint: client factory + generated spec types. */
+
+export type * from "./generated/shield.d.ts";
+export { createShieldClient } from "./shield-client.ts";

--- a/packages/openapi-client/src/storage.ts
+++ b/packages/openapi-client/src/storage.ts
@@ -1,0 +1,4 @@
+/** Edge Storage API entrypoint: client factory + generated spec types. */
+
+export type * from "./generated/storage.d.ts";
+export { createStorageClient } from "./storage-client.ts";

--- a/packages/openapi-client/src/stream.ts
+++ b/packages/openapi-client/src/stream.ts
@@ -1,0 +1,4 @@
+/** Stream API entrypoint: client factory + generated spec types. */
+
+export type * from "./generated/stream.d.ts";
+export { createStreamClient } from "./stream-client.ts";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
       "@bunny.net/openapi-client/generated/*": [
         "./packages/openapi-client/src/generated/*"
       ],
+      "@bunny.net/openapi-client/*": ["./packages/openapi-client/src/*"],
       "@bunny.net/sandbox": ["./packages/sandbox/src/index.ts"],
       "@bunny.net/sandbox/known-hosts": [
         "./packages/sandbox/src/known-hosts.ts"


### PR DESCRIPTION
Standalone-library DX improvements for `@bunny.net/openapi-client`, ahead of promoting it as a public SDK.

## What changed

### 1. `authMiddleware` is now exported

Consumers can compose their own `openapi-fetch` clients (custom specs, extra middleware) while keeping the same auth-header injection and error normalization:

```ts
import createClient from "openapi-fetch";
import { authMiddleware } from "@bunny.net/openapi-client";

const client = createClient<paths>({ baseUrl: "https://api.bunny.net" });
client.use(authMiddleware({ apiKey: "bny_..." }));
```

### 2. Per-API subpath entrypoints

Each API gets a subpath module bundling its client factory with every type generated from its spec, so type imports no longer route through the internal-looking `generated/*.d.ts` paths:

```ts
// before
import type { components } from "@bunny.net/openapi-client/generated/core.d.ts";
// after
import type { components } from "@bunny.net/openapi-client/core";
```

Entrypoints: `/core` (also carries the hand-authored DNS scan corrections), `/compute`, `/database`, `/magic-containers`, `/origin-errors`, `/shield`, `/storage`, `/stream`. The `./generated/*` export remains, so existing imports (including the CLI's and sandbox's ~30 call sites) keep working — migrating them can be a follow-up.

### 3. npm metadata

`package.json` now declares `description`, `license`, `repository` (+ `directory`), `homepage`, `bugs`, `keywords`, `sideEffects: false`, and `engines` (Node ≥ 18); a LICENSE file is bundled and shipped via `files`. Previously the npm page showed no license and no link back to this repo.

> **⚠️ Needs sign-off:** I set the license to **MIT**, matching the existing `@bunny.net/scriptable-dns-types` package — but no other package in this repo declares a license, so please confirm MIT is the intended choice (and the `BunnyWay d.o.o.` copyright line in LICENSE) before merging.

### Also in this PR

- README: documents the new entrypoints and `authMiddleware`, adds npm install command and runtime requirements (ESM-only, global `fetch`), and fixes the generated-types example — the previous `components["schemas"]["PullZone"]` never compiled (no such schema in the core spec); it now uses `DnsZoneModel`.
- Root `tsconfig.json`: `paths` mapping so in-repo consumers can use the new subpaths.
- AGENTS.md / CLAUDE.md: import conventions, file listing, publishing notes, and "Adding a new API" checklist updated.
- Changeset: minor bump for `@bunny.net/openapi-client`.

## Verification

- `bun test` — 845 pass, 0 fail (includes new `entrypoints.test.ts` covering the exports)
- `bun run typecheck`, `bun run lint` — clean
- `bun run build` in the package, then `npm pack` → installed the tarball into a fresh project: runtime imports of root + subpaths work, and `tsc --strict` under `nodenext` resolution passes against the new entrypoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6wJFmWRp8ebGFkpCmg7gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6wJFmWRp8ebGFkpCmg7gi)_