### PR TITLE
feat(sandbox): move cp under the files namespace

### DIFF
--- a/.changeset/sandbox-files-cp.md
+++ b/.changeset/sandbox-files-cp.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/cli": minor
+---
+
+feat(sandbox): breaking - `bunny sandbox cp` moves to `bunny sandbox files cp`, next to `bunny sandbox files list`, so every file command lives in one namespace; the old path no longer copies anything and instead errors with the exact replacement command to run, and `defineCommand` gains `hidden` for stubs like it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -463,14 +463,15 @@ bunny-cli/
 │           │   ├── list.ts               # List sandboxes
 │           │   ├── delete.ts             # Delete a sandbox and its MC app (--force)
 │           │   ├── exec.ts               # Run a command via SSH (-e/--env + --env-file inject temporary env vars; --timeout kills after N seconds, exit 124)
-│           │   ├── cp.ts                 # Copy a file to/from a sandbox over SFTP (<sandbox>:<path> picks direction)
 │           │   ├── resolve.ts            # Shared helpers: parseRemoteRef, sandboxFromName (rebuild a Sandbox from the stored record), connectSandbox (requires SSH endpoint)
 │           │   ├── ssh.ts                # Open an interactive SSH shell (-e/--env + --env-file inject temporary env vars)
 │           │   ├── ssh-exec.ts           # Shared SSH helpers: sshArgs, withSshEnv (askpass token), envPrefix (inline KEY='v' assignments)
 │           │   ├── env-args.ts           # Shared -e/--env + --env-file parsing: withEnvOptions, collectEnv, parseDotenv, splitPair
+│           │   ├── cp.ts                 # Hidden `cp [args..]` stub at the old `sandbox cp` path; errors with the shell-quoted `sandbox files cp` replacement (yargs would otherwise suggest `ls`)
 │           │   ├── files/                 # `sandbox files` (alias: file): file operations over SFTP
 │           │   │   ├── index.ts          # defineNamespace("files", ...)
-│           │   │   └── list.ts           # List files in a sandbox directory (alias: ls; bare name = /workplace, or <sandbox>:<path>)
+│           │   │   ├── list.ts           # List files in a sandbox directory (alias: ls; bare name = /workplace, or <sandbox>:<path>)
+│           │   │   └── cp.ts             # Copy a file to/from a sandbox over SFTP (<sandbox>:<path> picks direction)
 │           │   ├── url/                   # `sandbox url`: expose/list/delete public CDN endpoints for a port
 │           │   │   ├── index.ts          # defineNamespace("url", ...)
 │           │   │   └── add.ts / list.ts / delete.ts
@@ -558,6 +559,8 @@ export const myCommand = defineCommand<{
 ```
 
 The factory wraps every handler in a try/catch that distinguishes `UserError` (clean message + exit 1) from unexpected errors (stack trace in verbose mode + exit 2).
+
+Pass `hidden: true` to keep a command out of help while it still parses; used for moved-command stubs such as `bunny sandbox cp`, which errors and points at `bunny sandbox files cp`.
 
 ### `defineNamespace(command, describe, subcommands)`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1079,29 +1079,6 @@ bunny sandbox exec my-sandbox --timeout 30 -- bun run build
 
 Variables passed here apply only to that single command and are **not** persisted. For persistent variables, use [`bunny sandbox env`](#bunny-sandbox-env).
 
-#### `bunny sandbox cp`
-
-Copy a file between your machine and a sandbox over SFTP. Exactly one of the two paths must reference a sandbox as `<sandbox>:<path>`; the other is a local path. Remote paths follow the same rules as elsewhere — relative paths resolve against `/workplace`.
-
-```bash
-# Upload a file into the sandbox
-bunny sandbox cp ./app.js my-sandbox:/workplace/app.js
-
-# Upload relative to /workplace
-bunny sandbox cp ./app.js my-sandbox:app.js
-
-# An existing remote directory (or a trailing slash) keeps the source filename
-bunny sandbox cp ./app.js my-sandbox:/workplace/src
-
-# Download a file from the sandbox
-bunny sandbox cp my-sandbox:/workplace/out.log ./out.log
-
-# Download into an existing directory (keeps the source filename)
-bunny sandbox cp my-sandbox:/workplace/out.log ./logs/
-```
-
-Uploads preserve the local file's Unix mode (so executables stay executable). Only single files are supported — directory and sandbox-to-sandbox copies are not.
-
 #### `bunny sandbox files`
 
 Manage files inside a sandbox over SFTP. A bare sandbox name targets `/workplace`; use `<sandbox>:<path>` for a specific directory (relative paths resolve against `/workplace`).
@@ -1112,14 +1089,37 @@ bunny sandbox files list my-sandbox
 bunny sandbox files ls my-sandbox    # alias
 
 # List a specific directory
-bunny sandbox files ls my-sandbox:/workplace/src
-bunny sandbox files ls my-sandbox:src
+bunny sandbox files list my-sandbox:/workplace/src
+bunny sandbox files list my-sandbox:src
 
 # Machine-readable listing (name, type, size, mode)
-bunny sandbox files ls my-sandbox --output json
+bunny sandbox files list my-sandbox --output json
 ```
 
-Columns: Name, Type (`file`/`directory`/`symlink`/`other`), Size, Mode (octal permissions). To copy files in and out, use [`bunny sandbox cp`](#bunny-sandbox-cp).
+Columns: Name, Type (`file`/`directory`/`symlink`/`other`), Size, Mode (octal permissions).
+
+Copy a single file between your machine and a sandbox with `cp`. Exactly one of the two paths must reference a sandbox as `<sandbox>:<path>`; the other is a local path.
+
+```bash
+# Upload a file into the sandbox
+bunny sandbox files cp ./app.js my-sandbox:/workplace/app.js
+
+# Upload relative to /workplace
+bunny sandbox files cp ./app.js my-sandbox:app.js
+
+# An existing remote directory (or a trailing slash) keeps the source filename
+bunny sandbox files cp ./app.js my-sandbox:/workplace/src
+
+# Download a file from the sandbox
+bunny sandbox files cp my-sandbox:/workplace/out.log ./out.log
+
+# Download into an existing directory (keeps the source filename)
+bunny sandbox files cp my-sandbox:/workplace/out.log ./logs/
+```
+
+Uploads preserve the local file's Unix mode, so executables stay executable. Only single files are supported: directory and sandbox-to-sandbox copies are not.
+
+`cp` used to live at `bunny sandbox cp`. That path now errors with the equivalent `bunny sandbox files cp` command to run instead.
 
 #### `bunny sandbox ssh`
 

--- a/packages/cli/src/commands/sandbox/cp.test.ts
+++ b/packages/cli/src/commands/sandbox/cp.test.ts
@@ -1,29 +1,27 @@
 import { describe, expect, test } from "bun:test";
-import { resolveCopyDest } from "./cp.ts";
+import { rewriteCpCommand, sandboxCpMovedCommand } from "./cp.ts";
 
-describe("resolveCopyDest", () => {
-  test("a trailing slash appends the source filename without probing", async () => {
-    const path = await resolveCopyDest("/tmp/", "app.js", () => {
-      throw new Error("should not probe");
-    });
-    expect(path).toBe("/tmp/app.js");
+describe("the moved sandbox cp stub", () => {
+  test("stays out of help", () => {
+    expect(sandboxCpMovedCommand.describe).toBe(false);
   });
 
-  test("an existing directory appends the source filename", async () => {
-    expect(await resolveCopyDest("/tmp", "app.js", async () => true)).toBe(
-      "/tmp/app.js",
+  test("replays plain args against the new path", () => {
+    expect(rewriteCpCommand(["./app.js", "my-sandbox:app.js"])).toBe(
+      "bunny sandbox files cp ./app.js my-sandbox:app.js",
     );
+    expect(rewriteCpCommand([])).toBe("bunny sandbox files cp");
   });
 
-  test("a file or missing destination is used as-is", async () => {
-    expect(
-      await resolveCopyDest("/tmp/app.js", "app.js", async () => false),
-    ).toBe("/tmp/app.js");
-  });
-
-  test("relative directory destinations work too", async () => {
-    expect(await resolveCopyDest("src", "app.js", async () => true)).toBe(
-      "src/app.js",
+  test("quotes args the shell would otherwise re-split or interpret", () => {
+    expect(rewriteCpCommand(["my app.js", "box:my app.js"])).toBe(
+      "bunny sandbox files cp 'my app.js' 'box:my app.js'",
+    );
+    expect(rewriteCpCommand(["a;rm -rf b", ""])).toBe(
+      "bunny sandbox files cp 'a;rm -rf b' ''",
+    );
+    expect(rewriteCpCommand(["it's.js", "box:x"])).toBe(
+      "bunny sandbox files cp 'it'\\''s.js' box:x",
     );
   });
 });

--- a/packages/cli/src/commands/sandbox/cp.ts
+++ b/packages/cli/src/commands/sandbox/cp.ts
@@ -1,142 +1,33 @@
-import { stat } from "node:fs/promises";
-import { basename, posix } from "node:path";
-import { SandboxError } from "@bunny.net/sandbox";
 import { defineCommand } from "../../core/define-command.ts";
 import { UserError } from "../../core/errors.ts";
-import { logger } from "../../core/logger.ts";
-import { spinner } from "../../core/ui.ts";
-import { connectSandbox, parseRemoteRef } from "./resolve.ts";
 
-interface CpArgs {
-  source: string;
-  dest: string;
+/** Anything outside this set changes meaning once the hint is pasted back into a shell. */
+const SHELL_SAFE = /^[\w@%+=:,./-]+$/;
+
+function shellQuote(value: string): string {
+  if (value === "") return "''";
+  if (SHELL_SAFE.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-async function isDirectory(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isDirectory();
-  } catch {
-    return false;
-  }
+/** Replays what the user typed against the new command path. */
+export function rewriteCpCommand(args: readonly string[]): string {
+  return `bunny sandbox files cp ${args.map(shellQuote).join(" ")}`.trimEnd();
 }
 
-/**
- * Resolve where a copied file lands. A trailing slash or an existing
- * directory destination means "into it", keeping the source filename.
- * The trailing-slash check comes first so it never probes the destination.
- */
-export async function resolveCopyDest(
-  dest: string,
-  sourceName: string,
-  isDir: (path: string) => Promise<boolean>,
-): Promise<string> {
-  return dest.endsWith("/") || (await isDir(dest))
-    ? posix.join(dest, sourceName)
-    : dest;
-}
-
-export const sandboxCpCommand = defineCommand<CpArgs>({
-  command: "cp <source> <dest>",
-  describe: "Copy files between your machine and a sandbox.",
-  examples: [
-    ["$0 sandbox cp ./app.js my-sandbox:/workplace/app.js", "Upload a file"],
-    [
-      "$0 sandbox cp ./app.js my-sandbox:app.js",
-      "Upload (relative to workplace)",
-    ],
-    [
-      "$0 sandbox cp my-sandbox:/workplace/out.log ./out.log",
-      "Download a file",
-    ],
-  ],
+/** The old `bunny sandbox cp` path: without it yargs answers a stray `cp` with "Did you mean ls?". */
+export const sandboxCpMovedCommand = defineCommand<{ args?: string[] }>({
+  command: "cp [args..]",
+  describe: "Moved to `bunny sandbox files cp`.",
+  hidden: true,
 
   builder: (yargs) =>
-    yargs
-      .positional("source", {
-        type: "string",
-        demandOption: true,
-        describe: "Source path (local, or <sandbox>:<path>)",
-      })
-      .positional("dest", {
-        type: "string",
-        demandOption: true,
-        describe: "Destination path (local, or <sandbox>:<path>)",
-      }),
+    yargs.positional("args", { type: "string", array: true }) as any,
 
-  handler: async ({ source, dest, profile, apiKey, verbose, output }) => {
-    const srcRemote = parseRemoteRef(source);
-    const destRemote = parseRemoteRef(dest);
-
-    if (srcRemote && destRemote) {
-      throw new UserError(
-        "Sandbox-to-sandbox copies are not supported. One side must be a local path.",
-      );
-    }
-    const ref = srcRemote ?? destRemote;
-    if (!ref) {
-      throw new UserError(
-        "One path must reference a sandbox as <sandbox>:<path>.",
-      );
-    }
-    const sandbox = connectSandbox(ref.sandbox, profile, apiKey, verbose);
-
-    const uploading = Boolean(destRemote);
-    const spin = spinner(uploading ? "Uploading..." : "Downloading...");
-    spin.start();
-
-    let from: string;
-    let to: string;
-    try {
-      if (uploading) {
-        const local = source;
-        const info = await stat(local).catch(() => null);
-        if (!info) {
-          throw new UserError(`Local file not found: ${local}`);
-        }
-        if (info.isDirectory()) {
-          throw new UserError(
-            `${local} is a directory. Only single files can be copied.`,
-          );
-        }
-        const remotePath = await resolveCopyDest(
-          ref.path,
-          basename(local),
-          async (path) => (await sandbox.stat(path))?.type === "directory",
-        );
-        const content = Buffer.from(await Bun.file(local).arrayBuffer());
-        await sandbox.writeFiles([
-          { path: remotePath, content, mode: info.mode & 0o777 },
-        ]);
-        from = local;
-        to = `${ref.sandbox}:${remotePath}`;
-      } else {
-        const content = await sandbox.readFile(ref.path);
-        if (content === null) {
-          throw new UserError(`File not found in sandbox: ${ref.path}`);
-        }
-        const localPath = await resolveCopyDest(
-          dest,
-          basename(ref.path),
-          isDirectory,
-        );
-        await Bun.write(localPath, content);
-        from = `${ref.sandbox}:${ref.path}`;
-        to = localPath;
-      }
-    } catch (err) {
-      spin.stop();
-      if (err instanceof SandboxError) throw new UserError(err.message);
-      throw err;
-    } finally {
-      sandbox.disconnect();
-    }
-
-    spin.stop();
-
-    if (output === "json") {
-      logger.log(JSON.stringify({ from, to }, null, 2));
-      return;
-    }
-    logger.log(`Copied ${from} -> ${to}`);
+  handler: async ({ args }) => {
+    throw new UserError(
+      "`bunny sandbox cp` has moved to `bunny sandbox files cp`.",
+      `Run: ${rewriteCpCommand(args ?? [])}`,
+    );
   },
 });

--- a/packages/cli/src/commands/sandbox/files/cp.test.ts
+++ b/packages/cli/src/commands/sandbox/files/cp.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCopyDest, sandboxFilesCpCommand } from "./cp.ts";
+
+test("the canonical command lives under files and shows in help", () => {
+  expect(sandboxFilesCpCommand.command).toBe("cp <source> <dest>");
+  expect(sandboxFilesCpCommand.describe).toBe(
+    "Copy files between your machine and a sandbox.",
+  );
+});
+
+describe("resolveCopyDest", () => {
+  test("a trailing slash appends the source filename without probing", async () => {
+    const path = await resolveCopyDest("/tmp/", "app.js", () => {
+      throw new Error("should not probe");
+    });
+    expect(path).toBe("/tmp/app.js");
+  });
+
+  test("an existing directory appends the source filename", async () => {
+    expect(await resolveCopyDest("/tmp", "app.js", async () => true)).toBe(
+      "/tmp/app.js",
+    );
+  });
+
+  test("a file or missing destination is used as-is", async () => {
+    expect(
+      await resolveCopyDest("/tmp/app.js", "app.js", async () => false),
+    ).toBe("/tmp/app.js");
+  });
+
+  test("relative directory destinations work too", async () => {
+    expect(await resolveCopyDest("src", "app.js", async () => true)).toBe(
+      "src/app.js",
+    );
+  });
+});

--- a/packages/cli/src/commands/sandbox/files/cp.ts
+++ b/packages/cli/src/commands/sandbox/files/cp.ts
@@ -1,0 +1,142 @@
+import { stat } from "node:fs/promises";
+import { basename, posix } from "node:path";
+import { SandboxError } from "@bunny.net/sandbox";
+import { defineCommand } from "../../../core/define-command.ts";
+import { UserError } from "../../../core/errors.ts";
+import { logger } from "../../../core/logger.ts";
+import { spinner } from "../../../core/ui.ts";
+import { connectSandbox, parseRemoteRef } from "../resolve.ts";
+
+interface CpArgs {
+  source: string;
+  dest: string;
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve where a copied file lands. A trailing slash or an existing
+ * directory destination means "into it", keeping the source filename.
+ * The trailing-slash check comes first so it never probes the destination.
+ */
+export async function resolveCopyDest(
+  dest: string,
+  sourceName: string,
+  isDir: (path: string) => Promise<boolean>,
+): Promise<string> {
+  return dest.endsWith("/") || (await isDir(dest))
+    ? posix.join(dest, sourceName)
+    : dest;
+}
+
+export const sandboxFilesCpCommand = defineCommand<CpArgs>({
+  command: "cp <source> <dest>",
+  describe: "Copy files between your machine and a sandbox.",
+  examples: [
+    [
+      "$0 sandbox files cp ./app.js my-sandbox:/workplace/app.js",
+      "Upload a file",
+    ],
+    [
+      "$0 sandbox files cp ./app.js my-sandbox:app.js",
+      "Upload (relative to workplace)",
+    ],
+    ["$0 sandbox files cp my-sandbox:out.log ./out.log", "Download a file"],
+  ],
+
+  builder: (yargs) =>
+    yargs
+      .positional("source", {
+        type: "string",
+        demandOption: true,
+        describe: "Source path (local, or <sandbox>:<path>)",
+      })
+      .positional("dest", {
+        type: "string",
+        demandOption: true,
+        describe: "Destination path (local, or <sandbox>:<path>)",
+      }),
+
+  handler: async ({ source, dest, profile, apiKey, verbose, output }) => {
+    const srcRemote = parseRemoteRef(source);
+    const destRemote = parseRemoteRef(dest);
+
+    if (srcRemote && destRemote) {
+      throw new UserError(
+        "Sandbox-to-sandbox copies are not supported. One side must be a local path.",
+      );
+    }
+    const ref = srcRemote ?? destRemote;
+    if (!ref) {
+      throw new UserError(
+        "One path must reference a sandbox as <sandbox>:<path>.",
+      );
+    }
+    const sandbox = connectSandbox(ref.sandbox, profile, apiKey, verbose);
+
+    const uploading = Boolean(destRemote);
+    const spin = spinner(uploading ? "Uploading..." : "Downloading...");
+    spin.start();
+
+    let from: string;
+    let to: string;
+    try {
+      if (uploading) {
+        const local = source;
+        const info = await stat(local).catch(() => null);
+        if (!info) {
+          throw new UserError(`Local file not found: ${local}`);
+        }
+        if (info.isDirectory()) {
+          throw new UserError(
+            `${local} is a directory. Only single files can be copied.`,
+          );
+        }
+        const remotePath = await resolveCopyDest(
+          ref.path,
+          basename(local),
+          async (path) => (await sandbox.stat(path))?.type === "directory",
+        );
+        const content = Buffer.from(await Bun.file(local).arrayBuffer());
+        await sandbox.writeFiles([
+          { path: remotePath, content, mode: info.mode & 0o777 },
+        ]);
+        from = local;
+        to = `${ref.sandbox}:${remotePath}`;
+      } else {
+        const content = await sandbox.readFile(ref.path);
+        if (content === null) {
+          throw new UserError(`File not found in sandbox: ${ref.path}`);
+        }
+        const localPath = await resolveCopyDest(
+          dest,
+          basename(ref.path),
+          isDirectory,
+        );
+        await Bun.write(localPath, content);
+        from = `${ref.sandbox}:${ref.path}`;
+        to = localPath;
+      }
+    } catch (err) {
+      spin.stop();
+      if (err instanceof SandboxError) throw new UserError(err.message);
+      throw err;
+    } finally {
+      sandbox.disconnect();
+    }
+
+    spin.stop();
+
+    if (output === "json") {
+      logger.log(JSON.stringify({ from, to }, null, 2));
+      return;
+    }
+    logger.log(`Copied ${from} -> ${to}`);
+  },
+});

--- a/packages/cli/src/commands/sandbox/files/index.ts
+++ b/packages/cli/src/commands/sandbox/files/index.ts
@@ -1,9 +1,10 @@
 import { defineNamespace } from "../../../core/define-namespace.ts";
+import { sandboxFilesCpCommand } from "./cp.ts";
 import { sandboxFilesListCommand } from "./list.ts";
 
 export const sandboxFilesNamespace = defineNamespace(
   "files",
-  "Manage files inside a sandbox: list.",
-  [sandboxFilesListCommand],
+  "Manage files inside a sandbox: list, copy.",
+  [sandboxFilesListCommand, sandboxFilesCpCommand],
   ["file"],
 );

--- a/packages/cli/src/commands/sandbox/files/list.ts
+++ b/packages/cli/src/commands/sandbox/files/list.ts
@@ -20,9 +20,9 @@ export const sandboxFilesListCommand = defineCommand<ListArgs>({
   aliases: ["ls"],
   describe: "List files in a sandbox directory.",
   examples: [
-    ["$0 sandbox files ls my-sandbox", "List /workplace"],
-    ["$0 sandbox files ls my-sandbox:/workplace/src", "List a directory"],
-    ["$0 sandbox files ls my-sandbox:src --output json", "List as JSON"],
+    ["$0 sandbox files list my-sandbox", "List /workplace"],
+    ["$0 sandbox files list my-sandbox:src", "List a directory"],
+    ["$0 sandbox files list my-sandbox -o json", "List as JSON"],
   ],
 
   builder: (yargs) =>

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -1,5 +1,5 @@
 import { defineNamespace } from "../../core/define-namespace.ts";
-import { sandboxCpCommand } from "./cp.ts";
+import { sandboxCpMovedCommand } from "./cp.ts";
 import { sandboxCreateCommand } from "./create.ts";
 import { sandboxDeleteCommand } from "./delete.ts";
 import { sandboxEnvNamespace } from "./env/index.ts";
@@ -17,10 +17,10 @@ export const sandboxNamespace = defineNamespace(
     sandboxListCommand,
     sandboxDeleteCommand,
     sandboxExecCommand,
-    sandboxCpCommand,
     sandboxFilesNamespace,
     sandboxSshCommand,
     sandboxUrlNamespace,
     sandboxEnvNamespace,
+    sandboxCpMovedCommand,
   ],
 );

--- a/packages/cli/src/core/define-command.ts
+++ b/packages/cli/src/core/define-command.ts
@@ -6,6 +6,8 @@ interface CommandDef<A = Record<string, never>> {
   command: string;
   aliases?: readonly string[];
   describe: string;
+  /** Keeps the command out of help while it still runs (e.g. a deprecated mount point). */
+  hidden?: boolean;
   /** Usage examples shown in `--help` output. Each entry is `[command, description]`. */
   examples?: ReadonlyArray<readonly [string, string]>;
   /** Define command-specific flags and positional arguments. */
@@ -57,7 +59,7 @@ export function defineCommand<A>(def: CommandDef<A>): CommandModule {
   return {
     command: def.command,
     aliases: def.aliases,
-    describe: def.describe,
+    describe: def.hidden ? (false as never) : def.describe,
     builder: wrappedBuilder as any,
     handler: async (argv) => {
       const args = argv as unknown as A & GlobalArgs;

--- a/skills/bunny-cli/SKILL.md
+++ b/skills/bunny-cli/SKILL.md
@@ -72,7 +72,7 @@ Use this to route to the correct reference file:
 - **DNS (zones, delegation checks, records, presets, BIND import/export, DNSSEC, logging, Scriptable DNS scripts)** -> `references/dns.md`
 - **Edge Scripts (init, create, deploy, link, stats, deployments/rollback, env vars, custom domains)** -> `references/scripts.md`
 - **Static sites (create, deploy, rollback, custom domains, domain-gated previews, GitHub Actions)** -> `references/sites.md`
-- **Sandboxes (create, exec, ssh, cp, files, public URLs, persistent env vars, Claude Code auth)** -> `references/sandbox.md`
+- **Sandboxes (create, exec, ssh, files list/cp, public URLs, persistent env vars, Claude Code auth)** -> `references/sandbox.md`
 - **Make raw API requests** -> `references/api.md`
 - **CLI doesn't have a command for it** -> use `bunny api` as a fallback (see `references/api.md`)
 

--- a/skills/bunny-cli/references/sandbox.md
+++ b/skills/bunny-cli/references/sandbox.md
@@ -16,8 +16,8 @@ bunny sandbox url add my-sandbox 3000        # public HTTPS URL for port 3000
 bunny sandbox delete my-sandbox --force
 
 # Move files in and out
-bunny sandbox cp ./app.js my-sandbox:app.js  # relative paths resolve against /workplace
-bunny sandbox cp my-sandbox:out.log ./out.log
+bunny sandbox files cp ./app.js my-sandbox:app.js  # relative paths resolve against /workplace
+bunny sandbox files cp my-sandbox:out.log ./out.log
 
 # Interactive work
 bunny sandbox ssh my-sandbox
@@ -90,28 +90,26 @@ bunny sandbox ssh my-sandbox -e DEBUG=1 --env-file .env   # session-only variabl
 
 ---
 
-## `bunny sandbox cp`
-
-Copy a single file between the local machine and a sandbox over SFTP. Exactly one path must be `<sandbox>:<path>`; relative remote paths resolve against `/workplace`. Uploads preserve the local Unix mode. Directory and sandbox-to-sandbox copies are not supported.
-
-```bash
-bunny sandbox cp ./app.js my-sandbox:/workplace/app.js
-bunny sandbox cp ./app.js my-sandbox:app.js            # relative to /workplace
-bunny sandbox cp ./app.js my-sandbox:/workplace/src    # existing dir (or trailing slash) keeps the filename
-bunny sandbox cp my-sandbox:/workplace/out.log ./logs/   # ./logs must already exist
-```
-
----
-
 ## `bunny sandbox files`
 
-Inspect files over SFTP. A bare sandbox name targets `/workplace`; use `<sandbox>:<path>` for a specific directory.
+Manage files over SFTP. A bare sandbox name targets `/workplace`; use `<sandbox>:<path>` for a specific directory.
 
 ```bash
 bunny sandbox files list my-sandbox               # alias: ls
-bunny sandbox files ls my-sandbox:src
-bunny sandbox files ls my-sandbox --output json   # name, type, size, mode
+bunny sandbox files list my-sandbox:src
+bunny sandbox files list my-sandbox --output json   # name, type, size, mode
 ```
+
+`cp` copies a single file between the local machine and a sandbox. Exactly one path must be `<sandbox>:<path>`; relative remote paths resolve against `/workplace`. Uploads preserve the local Unix mode. Directory and sandbox-to-sandbox copies are not supported.
+
+```bash
+bunny sandbox files cp ./app.js my-sandbox:/workplace/app.js
+bunny sandbox files cp ./app.js my-sandbox:app.js            # relative to /workplace
+bunny sandbox files cp ./app.js my-sandbox:/workplace/src    # existing dir (or trailing slash) keeps the filename
+bunny sandbox files cp my-sandbox:/workplace/out.log ./logs/   # ./logs must already exist
+```
+
+The old `bunny sandbox cp` path errors and prints the `bunny sandbox files cp` command to run instead.
 
 ---
 


### PR DESCRIPTION
Closes #144 

I propose we just change it now pre-v1.0 and I didn't mark this as a major breaking change since we're pre-1.0, so I think it's fine. I added a hint for those running the old way that the command moved. Again, I did consider adding a hidden alias for backwards compat, but we're still in early build phase of the CLI that this kind of thing is fine to break early doors.

@amir-at-bunny @jedisct1 let me know what you both think.