### PR TITLE
fix(apps): preserve existing container env vars on deploy and push when bunny.jsonc has no env block

### DIFF
--- a/.changeset/apps-deploy-preserve-env.md
+++ b/.changeset/apps-deploy-preserve-env.md
@@ -1,0 +1,6 @@
+---
+"@bunny.net/config": patch
+"@bunny.net/cli": patch
+---
+
+Keep existing container env vars on `apps deploy` and `apps push` when bunny.jsonc has no env block

--- a/packages/config/src/convert.test.ts
+++ b/packages/config/src/convert.test.ts
@@ -482,4 +482,74 @@ describe("configToPatchRequest", () => {
     );
     expect(req.containerTemplates?.[1]?.id).toBeUndefined();
   });
+
+  test("no env block carries over the existing template's vars", () => {
+    const existing = app({
+      containerTemplates: [
+        template({
+          id: "ct_remote_1",
+          name: "api",
+          environmentVariables: [{ name: "FOO", value: "bar" }],
+        }),
+      ],
+    });
+    const req = configToPatchRequest(
+      {
+        version: CURRENT_VERSION,
+        app: { name: "x", containers: { api: { image: "nginx" } } },
+      },
+      existing,
+    );
+    expect(req.containerTemplates?.[0]?.environmentVariables).toEqual([
+      { name: "FOO", value: "bar" },
+    ]);
+  });
+
+  test("env block in config replaces the existing template's vars", () => {
+    const existing = app({
+      containerTemplates: [
+        template({
+          id: "ct_remote_1",
+          name: "api",
+          environmentVariables: [{ name: "FOO", value: "bar" }],
+        }),
+      ],
+    });
+    const req = configToPatchRequest(
+      {
+        version: CURRENT_VERSION,
+        app: {
+          name: "x",
+          containers: { api: { image: "nginx", env: { BAZ: "qux" } } },
+        },
+      },
+      existing,
+    );
+    expect(req.containerTemplates?.[0]?.environmentVariables).toEqual([
+      { name: "BAZ", value: "qux" },
+    ]);
+  });
+
+  test("empty env block clears the existing template's vars", () => {
+    const existing = app({
+      containerTemplates: [
+        template({
+          id: "ct_remote_1",
+          name: "api",
+          environmentVariables: [{ name: "FOO", value: "bar" }],
+        }),
+      ],
+    });
+    const req = configToPatchRequest(
+      {
+        version: CURRENT_VERSION,
+        app: {
+          name: "x",
+          containers: { api: { image: "nginx", env: {} } },
+        },
+      },
+      existing,
+    );
+    expect(req.containerTemplates?.[0]?.environmentVariables).toEqual([]);
+  });
 });

--- a/packages/config/src/convert.ts
+++ b/packages/config/src/convert.ts
@@ -254,7 +254,12 @@ export function configToPatchRequest(
         ? existingApp.containerTemplates[0]
         : existingApp.containerTemplates.find((ct) => ct.name === name);
     const merged = mergeRegistry(name, c, registries);
-    containers.push(containerConfigToRequest(name, merged, existing?.id));
+    const req = containerConfigToRequest(name, merged, existing?.id);
+    // PATCH replaces the whole template, so a config without an env block must carry over the server's vars or they get wiped.
+    if (!merged.env && existing?.environmentVariables?.length) {
+      req.environmentVariables = existing.environmentVariables;
+    }
+    containers.push(req);
     collectVolumes(merged, volumes, seenVolumes);
   }
 


### PR DESCRIPTION
Fixes #197.

## What changed

`configToPatchRequest` in `@bunny.net/config` now carries the server's existing `environmentVariables` into the PATCH payload for any container whose `bunny.jsonc` config has no `env` block.

## Why

`PATCH /apps` replaces each container template wholesale rather than merging it. When `bunny.jsonc` has no `env` block, the request previously sent the template without `environmentVariables`, so `apps deploy` and `apps push` silently wiped every env var that had been set on the app (via the dashboard or an earlier deploy).

## Notes for review

- The carry-over only applies when the config has no `env` block at all. A config *with* an `env` block remains the source of truth, and an explicitly empty `env: {}` still clears the server's vars; both contracts are unchanged.
- Matching against the existing app reuses the same logic as the rest of the patch path: single-template apps match positionally, multi-template apps match by container name.
- New tests in `packages/config/src/convert.test.ts` cover all three cases: no env block preserves, a populated env block replaces, an empty env block clears.